### PR TITLE
feat: tie events to authenticated user

### DIFF
--- a/supabase/migrations/20240702000000_add_user_id_to_events.sql
+++ b/supabase/migrations/20240702000000_add_user_id_to_events.sql
@@ -1,0 +1,11 @@
+ALTER TABLE public.events ADD COLUMN user_id uuid REFERENCES auth.users(id);
+
+ALTER TABLE public.events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can insert own events" ON public.events
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can view own events" ON public.events
+  FOR SELECT
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- validate `Authorization` header in ingest function using `supabase.auth.getUser`
- store authenticated `user_id` on event inserts
- add migration to add `user_id` column and RLS policies for events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acdc979954832db46467604bb2660a