### PR TITLE
Handle Supabase auth events in popup

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -58,6 +58,16 @@ async function renderAuthState() {
   }
 }
 
+// React to auth state changes (e.g., token refresh or sign out)
+supabase.auth.onAuthStateChange(async (event, session) => {
+  if (event === "TOKEN_REFRESHED") {
+    chrome.storage.local.set({ aidetox_token: session?.access_token || "" });
+  } else if (event === "SIGNED_OUT") {
+    chrome.storage.local.remove("aidetox_token");
+  }
+  await renderAuthState();
+});
+
 // Toggle forms
 $("#btn-show-signup")?.addEventListener("click", () => {
   hide($("#form-login"));


### PR DESCRIPTION
## Summary
- listen for Supabase auth state changes in popup
- update or remove `aidetox_token` based on `TOKEN_REFRESHED` and `SIGNED_OUT`
- re-render auth UI after each auth state change

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acdc9946ec832dafd3427270d02564