### PR TITLE
Allow anonymous username checks and handle taken error

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -143,9 +143,12 @@ $("#form-signup")?.addEventListener("submit", async (e) => {
     .insert({ id: userId, username });
 
   if (profErr) {
-    // Unique violation race fallback
-    if (profErr.code === "23505") {
-      msg.textContent = "Username just got taken—please pick another.";
+    // Handle unique constraint or explicit "username taken" errors
+    const taken =
+      profErr.code === "23505" ||
+      profErr.message?.toLowerCase().includes("username taken");
+    if (taken) {
+      msg.textContent = "That username is taken. Please choose another.";
     } else {
       msg.textContent = "Could not save profile.";
     }

--- a/supabase/migrations/20250825221234_profiles.sql
+++ b/supabase/migrations/20250825221234_profiles.sql
@@ -12,3 +12,9 @@ create policy "Individuals can manage own profile"
   for all
   using (auth.uid() = id)
   with check (auth.uid() = id);
+
+-- Allow anonymous username availability checks
+create policy "Anyone can read usernames"
+  on profiles
+  for select
+  using (true);


### PR DESCRIPTION
## Summary
- allow public `SELECT` on profiles so clients can check username availability
- guide users when profile insert reports a `username taken` error

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acea3e4b40832dbc745e2de4040b5f