### PR TITLE
Expose profile save errors in popup

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -184,7 +184,8 @@ $("#form-signup")?.addEventListener("submit", async (e) => {
     if (isDuplicate) {
       msg.textContent = "Username just got taken — please pick another.";
     } else {
-      msg.textContent = "Could not save profile.";
+      msg.textContent = profErrMsg || "Could not save profile.";
+      console.error("Profile creation failed:", profErrMsg);
     }
     return;
   }


### PR DESCRIPTION
## Summary
- Show detailed profile creation errors to users
- Log profile creation errors for easier debugging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aced720a2c832da421e429f910dc6c