### PR TITLE
Fix friends lookup in leaderboard function

### DIFF
--- a/supabase/functions/leaderboards/index.ts
+++ b/supabase/functions/leaderboards/index.ts
@@ -40,14 +40,14 @@ serve(async (req) => {
 
     const { data: friendRows, error: friendsErr } = await supa
       .from("friends")
-      .select("user_id, friend_id")
-      .or(`user_id.eq.${meId},friend_id.eq.${meId}`);
+      .select("owner, friend")
+      .or(`owner.eq.${meId},friend.eq.${meId}`);
     if (friendsErr) {
       return new Response(friendsErr.message, { status: 500, headers: cors });
     }
     friendIds = new Set([meId]);
     for (const row of friendRows || []) {
-      friendIds.add(row.user_id === meId ? row.friend_id : row.user_id);
+      friendIds.add(row.owner === meId ? row.friend : row.owner);
     }
   }
   const since = new Date(); since.setMonth(since.getMonth() - 6);


### PR DESCRIPTION
## Summary
- use new `owner`/`friend` columns when querying friendships
- update friendship iteration to derive the proper friend IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a6950264832d9a55752a77294be5