### PR TITLE
feat: record events by profile

### DIFF
--- a/supabase/functions/ingest/index.ts
+++ b/supabase/functions/ingest/index.ts
@@ -34,7 +34,7 @@ serve(async (req) => {
 
   await supa.from("devices").upsert({ id: device_id, last_seen: new Date().toISOString() }, { onConflict: "id" });
 
-  const { error } = await supa.from("events").insert({ user_id: user.id, device_id, event, at, domain, url, reason, unlock_delay_ms });
+  const { error } = await supa.from("events").insert({ profile_id: user.id, device_id, event, at, domain, url, reason, unlock_delay_ms });
   if (error) return new Response(error.message, { status: 500, headers: cors });
 
   return new Response(JSON.stringify({ ok: true }), { headers: { ...cors, "content-type": "application/json" } });

--- a/supabase/migrations/20250901000000_add_profile_id_to_events.sql
+++ b/supabase/migrations/20250901000000_add_profile_id_to_events.sql
@@ -1,0 +1,13 @@
+ALTER TABLE public.events RENAME COLUMN user_id TO profile_id;
+ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_user_id_fkey;
+ALTER TABLE public.events ADD CONSTRAINT events_profile_id_fkey FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE;
+DROP POLICY IF EXISTS "Users can insert own events" ON public.events;
+DROP POLICY IF EXISTS "Users can view own events" ON public.events;
+DROP POLICY IF EXISTS "Individuals can manage own events" ON public.events;
+CREATE POLICY "Individuals can manage own events"
+  ON public.events
+  FOR ALL
+  USING (auth.uid() = profile_id)
+  WITH CHECK (auth.uid() = profile_id);
+DROP INDEX IF EXISTS events_user_id_idx;
+CREATE INDEX events_profile_id_idx ON public.events (profile_id);


### PR DESCRIPTION
## Summary
- log events in Supabase with `profile_id`
- migrate events table to use `profile_id` and update policies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b0a69c6e84832da1ded7753f8f41bb