### PR TITLE
Use display_name instead of username

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -108,10 +108,6 @@
           <!-- Sign Up form -->
           <form id="form-signup" class="hidden" autocomplete="off">
             <div class="set-row">
-              <div class="set-row-title">Username</div>
-              <input type="text" id="su-username" class="set-input-wide" placeholder="Pick a username (permanent)" required />
-            </div>
-            <div class="set-row">
               <div class="set-row-title">Email</div>
               <input type="email" id="su-email" class="set-input-wide" placeholder="you@example.com" required />
             </div>
@@ -123,7 +119,6 @@
               <button type="submit" class="btn btn-secondary">Create account</button>
               <span id="su-msg" class="muted small"></span>
             </div>
-            <div class="muted small">Your username is unique and permanent. We’ll reserve it on sign-up.</div>
           </form>
 
           <!-- Log In form -->

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -14,8 +14,7 @@ export async function ensureProfile(user) {
   if (!user?.id) return;
   await supabase.from('profiles').upsert({
     id: user.id,
-    display_name: user.user_metadata?.full_name || null,
-    username: user.user_metadata?.username || user.email?.split('@')[0] || null
+    display_name: user.user_metadata?.full_name || null
   });
 }
 

--- a/supabase/functions/create-profile/index.ts
+++ b/supabase/functions/create-profile/index.ts
@@ -19,14 +19,14 @@ serve(async (req) => {
     return new Response("Bad JSON", { status: 400, headers: cors });
   }
 
-  const { userId, username } = body || {};
+  const { userId, display_name } = body || {};
   if (!userId) {
     return new Response("userId required", { status: 400, headers: cors });
   }
 
   const supa = createClient(supabaseUrl, serviceKey, { auth: { persistSession: false } });
 
-  const { error } = await supa.from("profiles").upsert({ id: userId, username });
+  const { error } = await supa.from("profiles").upsert({ id: userId, display_name });
   if (error) return new Response(error.message, { status: 500, headers: cors });
 
   return new Response(JSON.stringify({ ok: true }), { headers: { ...cors, "content-type": "application/json" } });

--- a/supabase/migrations/20250825221234_profiles.sql
+++ b/supabase/migrations/20250825221234_profiles.sql
@@ -1,7 +1,7 @@
 -- Create profiles table
 create table profiles (
   id uuid primary key references auth.users(id) on delete cascade,
-  username text unique,
+  display_name text,
   created_at timestamptz default timezone('utc', now())
 );
 
@@ -12,9 +12,3 @@ create policy "Individuals can manage own profile"
   for all
   using (auth.uid() = id)
   with check (auth.uid() = id);
-
--- Allow anonymous username availability checks
-create policy "Anyone can read usernames"
-  on profiles
-  for select
-  using (true);


### PR DESCRIPTION
## Summary
- Upsert `display_name` when creating profiles and add the column to the schema.
- Drop username usage in client profile helpers and sign-up flow.
- Simplify sign-up form to only require email and password.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a6a32ac8832d97aa2febd7358615