### PR TITLE
Add leaderboard SQL functions

### DIFF
--- a/supabase/migrations/20250825221249_lb_saves.sql
+++ b/supabase/migrations/20250825221249_lb_saves.sql
@@ -1,0 +1,12 @@
+-- Create lb_saves function
+CREATE OR REPLACE FUNCTION public.lb_saves(p_since timestamptz)
+RETURNS TABLE(identity uuid, value bigint)
+LANGUAGE sql STABLE AS $$
+  SELECT profile_id AS identity,
+         COUNT(*)::bigint AS value
+  FROM events
+  WHERE event = 'close' AND at >= p_since
+  GROUP BY profile_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.lb_saves(timestamptz) TO anon;

--- a/supabase/migrations/20250825221250_lb_noassist_streak.sql
+++ b/supabase/migrations/20250825221250_lb_noassist_streak.sql
@@ -1,0 +1,12 @@
+-- Create lb_noassist_streak function
+CREATE OR REPLACE FUNCTION public.lb_noassist_streak(p_since timestamptz)
+RETURNS TABLE(identity uuid, value bigint)
+LANGUAGE sql STABLE AS $$
+  SELECT profile_id AS identity,
+         DATE_PART('day', NOW() - COALESCE(MAX(at) FILTER (WHERE event = 'assist'), p_since))::bigint AS value
+  FROM events
+  WHERE at >= p_since
+  GROUP BY profile_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.lb_noassist_streak(timestamptz) TO anon;

--- a/supabase/migrations/20250825221251_lb_offgrid_streak.sql
+++ b/supabase/migrations/20250825221251_lb_offgrid_streak.sql
@@ -1,0 +1,12 @@
+-- Create lb_offgrid_streak function
+CREATE OR REPLACE FUNCTION public.lb_offgrid_streak(p_since timestamptz)
+RETURNS TABLE(identity uuid, value bigint)
+LANGUAGE sql STABLE AS $$
+  SELECT profile_id AS identity,
+         DATE_PART('day', NOW() - COALESCE(MAX(at) FILTER (WHERE event = 'proceed'), p_since))::bigint AS value
+  FROM events
+  WHERE at >= p_since
+  GROUP BY profile_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.lb_offgrid_streak(timestamptz) TO anon;


### PR DESCRIPTION
## Summary
- add SQL function lb_saves counting 'close' events per profile
- add SQL function lb_noassist_streak measuring days since last 'assist'
- add SQL function lb_offgrid_streak measuring days since last 'proceed'

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0a6b0f8fc832da3a1003ccfb4a730