### PR TITLE
Inject Supabase config through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # aiDetox
+
+## Build
+
+The build process expects Supabase credentials to be provided as environment variables:
+
+```bash
+SUPABASE_URL=your-project-url SUPABASE_ANON_KEY=your-anon-key npm run build
+```
+
+These values are injected at bundle time and used by the extension to connect to Supabase.

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,7 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
-export const SUPABASE_URL = 'https://ltjtjgdjllmbyknaygof.supabase.co';
-export const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx0anRqZ2RqbGxtYnlrbmF5Z29mIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYxNDkxOTAsImV4cCI6MjA3MTcyNTE5MH0.tMfU0stBJZ52IKWOd7A0HGSWxXMhvXVqd9dyredUEHM';
+// Read Supabase credentials from environment variables injected at build time
+export const SUPABASE_URL = process.env.SUPABASE_URL;
+export const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 // webpack.config.js
 const path = require("path");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const webpack = require("webpack");
 
 module.exports = {
   mode: process.env.NODE_ENV === "development" ? "development" : "production",
@@ -46,6 +47,10 @@ module.exports = {
         { from: "src/content.css", to: "content.css" },
         { from: "src/icons", to: "icons", noErrorOnMissing: true }, // fine if missing
       ],
+    }),
+    new webpack.DefinePlugin({
+      "process.env.SUPABASE_URL": JSON.stringify(process.env.SUPABASE_URL || ""),
+      "process.env.SUPABASE_ANON_KEY": JSON.stringify(process.env.SUPABASE_ANON_KEY || ""),
     }),
   ],
 


### PR DESCRIPTION
## Summary
- Read Supabase URL and anon key from environment variables instead of hard-coded constants
- Inject these values during bundling via Webpack's DefinePlugin
- Document required environment variables in README

## Testing
- `npm test` (fails: Missing script: "test")
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a6b6b3e8832db178432c450b16f9