### PR TITLE
feat: add default streak function parameters

### DIFF
--- a/supabase/migrations/20250825221250_lb_noassist_streak.sql
+++ b/supabase/migrations/20250825221250_lb_noassist_streak.sql
@@ -1,5 +1,5 @@
 -- Create lb_noassist_streak function
-CREATE OR REPLACE FUNCTION public.lb_noassist_streak(p_since timestamptz)
+CREATE OR REPLACE FUNCTION public.lb_noassist_streak(p_since timestamptz DEFAULT 'epoch'::timestamptz)
 RETURNS TABLE(identity uuid, value bigint)
 LANGUAGE sql STABLE AS $$
   SELECT profile_id AS identity,

--- a/supabase/migrations/20250825221251_lb_offgrid_streak.sql
+++ b/supabase/migrations/20250825221251_lb_offgrid_streak.sql
@@ -1,5 +1,5 @@
 -- Create lb_offgrid_streak function
-CREATE OR REPLACE FUNCTION public.lb_offgrid_streak(p_since timestamptz)
+CREATE OR REPLACE FUNCTION public.lb_offgrid_streak(p_since timestamptz DEFAULT 'epoch'::timestamptz)
 RETURNS TABLE(identity uuid, value bigint)
 LANGUAGE sql STABLE AS $$
   SELECT profile_id AS identity,


### PR DESCRIPTION
## Summary
- allow calling `lb_noassist_streak` and `lb_offgrid_streak` without parameters by defaulting `p_since` to `'epoch'`

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1e4a8a7b8832d9a8d28f741399e25