### PR TITLE
fix: update no-assist streak description

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -59,7 +59,7 @@
         <div class="board-card">
           <div class="board-head">
             <div class="board-title">No-Assist Streak</div>
-            <div class="board-sub">Visited but didn’t proceed</div>
+            <div class="board-sub">Didn't visit AI sites</div>
           </div>
           <div class="board-body">
             <div id="lb-noai-list" class="ranklist"></div>


### PR DESCRIPTION
## Summary
- clarify No-Assist Streak leaderboard description to reflect days with no AI site visits

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1fb1f06b4832dbd559d9f9849b549