### PR TITLE
feat: add configurable prompt counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aiDetox
 
-Browser extension to journal and limit your AI usage. You can now set how many times you're allowed to use AI within an hour, day, or week before sites get blocked.
+Browser extension to journal and limit your AI usage. Set how many consecutive times you can use AI before a confirmation prompt appears, then the counter resets after you respond.
 
 ## Build
 

--- a/src/content.js
+++ b/src/content.js
@@ -19,57 +19,15 @@
     const TTL = 30 * 1000;           // re-prompt after 30s
     const MIN_CHARS = 10;            // min reason length
     const UNLOCK_DELAY = 10 * 1000;  // 10 seconds lock
-
-    const LIMIT_COUNT_KEY = 'aidetox_limit_count';
-    const LIMIT_PERIOD_KEY = 'aidetox_limit_period';
-    const LOG_KEY = 'aidetox_log';
+    const FREE_USES_KEY = 'aidetox_free_uses';
+    const USES_BEFORE_PROMPT_KEY = 'aidetox_uses_before_prompt';
     const settings = await new Promise(resolve => {
-      chrome.storage.local.get([LIMIT_COUNT_KEY, LIMIT_PERIOD_KEY, LOG_KEY], resolve);
+      chrome.storage.local.get([FREE_USES_KEY, USES_BEFORE_PROMPT_KEY], resolve);
     });
-    const limitCount = settings[LIMIT_COUNT_KEY] ?? 0;
-    const limitPeriod = settings[LIMIT_PERIOD_KEY] || 'day';
-    const log = settings[LOG_KEY] || [];
-    const periodMs = limitPeriod === 'hour'
-      ? 60 * 60 * 1000
-      : limitPeriod === 'week'
-        ? 7 * 24 * 60 * 60 * 1000
-        : 24 * 60 * 60 * 1000;
-    const now = Date.now();
-    const used = (log || []).filter(e => e.event === 'proceed' && now - e.at < periodMs).length;
-    if (limitCount > 0 && used >= limitCount) {
-      const block = document.createElement('div');
-      block.id = 'aidetox-overlay';
-      block.innerHTML = `
-        <div class="aidetox-card" role="dialog" aria-modal="true">
-          <h1 class="aidetox-title">AI usage limit reached</h1>
-          <p class="aidetox-text">You've hit your ${limitCount} uses per ${limitPeriod}. Take a break.</p>
-          <div class="aidetox-actions">
-            <button class="aidetox-btn" id="aidetox-no">Close this</button>
-          </div>
-        </div>`;
-      const lock = document.createElement('style');
-      lock.textContent = `html, body { overflow: hidden !important; }`;
-      document.documentElement.appendChild(lock);
-      document.documentElement.appendChild(block);
-      block.querySelector('#aidetox-no')?.addEventListener('click', () => {
-        try {
-          api?.runtime?.sendMessage?.({
-            type: 'AIDETOX_LOG',
-            event: 'close',
-            domain: DOMAIN,
-            url: location.href,
-            unlock_delay_ms: 0,
-          });
-        } catch {}
-        setTimeout(() => {
-          if (api && api.runtime && api.runtime.sendMessage) {
-            api.runtime.sendMessage({ type: 'AIDETOX_CLOSE_TAB' });
-          } else {
-            try { window.close(); } catch {}
-            try { location.replace('about:blank'); } catch {}
-          }
-        }, 80);
-      });
+    const freeUses = settings[FREE_USES_KEY] ?? 0;
+    const usesBeforePrompt = settings[USES_BEFORE_PROMPT_KEY] ?? 0;
+    if (usesBeforePrompt > 0 && freeUses < usesBeforePrompt) {
+      chrome.storage.local.set({ [FREE_USES_KEY]: freeUses + 1 });
       return;
     }
   
@@ -141,6 +99,7 @@
           unlock_delay_ms: UNLOCK_DELAY
         });
       } catch {}
+      chrome.storage.local.set({ [FREE_USES_KEY]: 0 });
       // small delay to help ensure the log is sent before the tab closes
       setTimeout(() => {
         if (api && api.runtime && api.runtime.sendMessage) {
@@ -217,7 +176,8 @@
           unlock_delay_ms: UNLOCK_DELAY
         });
       } catch {}
-  
+      chrome.storage.local.set({ [FREE_USES_KEY]: 0 });
+
       // short allow buffer
       try { localStorage.setItem(ALLOW_KEY, String(Date.now() + TTL)); } catch {}
   

--- a/src/popup.html
+++ b/src/popup.html
@@ -163,19 +163,13 @@
           </div>
         </div>
 
-        <!-- Usage Limit -->
+        <!-- Unprompted uses setting -->
         <div class="set-card">
-          <div class="set-title">Usage Limit</div>
+          <div class="set-title">Unprompted uses before prompting</div>
           <div class="set-row">
-            <div class="set-row-title">Allow</div>
-            <input type="number" id="set-limit-count" class="set-input" min="0" step="1" value="0" />
-            <select id="set-limit-period" class="set-input" style="width:120px">
-              <option value="hour">uses / hour</option>
-              <option value="day" selected>uses / day</option>
-              <option value="week">uses / week</option>
-            </select>
+            <input type="number" id="set-uses-before" class="set-input" min="0" step="1" value="0" />
           </div>
-          <div class="muted small">0 disables limit.</div>
+          <div class="muted small">0 prompts every visit.</div>
         </div>
 
         <!-- Data -->

--- a/src/popup.js
+++ b/src/popup.js
@@ -17,30 +17,23 @@ const hide = (el) => el && el.classList.add("hidden");
 let LB_SCOPE = "global"; // "global" | "friends"
 
 // Settings keys
-const LIMIT_COUNT_KEY = "aidetox_limit_count";
-const LIMIT_PERIOD_KEY = "aidetox_limit_period";
+const USES_BEFORE_PROMPT_KEY = "aidetox_uses_before_prompt";
 
 function loadSettings() {
-  chrome.storage.local.get([LIMIT_COUNT_KEY, LIMIT_PERIOD_KEY], (res) => {
-    const count = res[LIMIT_COUNT_KEY] ?? 0;
-    const period = res[LIMIT_PERIOD_KEY] || "day";
-    const countEl = document.getElementById("set-limit-count");
-    const periodEl = document.getElementById("set-limit-period");
-    if (countEl) countEl.value = count;
-    if (periodEl) periodEl.value = period;
+  chrome.storage.local.get([USES_BEFORE_PROMPT_KEY], (res) => {
+    const uses = res[USES_BEFORE_PROMPT_KEY] ?? 0;
+    const usesEl = document.getElementById("set-uses-before");
+    if (usesEl) usesEl.value = uses;
   });
 }
 
 function saveSettings() {
-  const countEl = document.getElementById("set-limit-count");
-  const periodEl = document.getElementById("set-limit-period");
-  const count = parseInt(countEl?.value, 10) || 0;
-  const period = periodEl?.value || "day";
-  chrome.storage.local.set({ [LIMIT_COUNT_KEY]: count, [LIMIT_PERIOD_KEY]: period });
+  const usesEl = document.getElementById("set-uses-before");
+  const uses = parseInt(usesEl?.value, 10) || 0;
+  chrome.storage.local.set({ [USES_BEFORE_PROMPT_KEY]: uses });
 }
 
-document.getElementById("set-limit-count")?.addEventListener("change", saveSettings);
-document.getElementById("set-limit-period")?.addEventListener("change", saveSettings);
+document.getElementById("set-uses-before")?.addEventListener("change", saveSettings);
 
 // -------------------------
 // Device ID (for anon/global leaderboards, etc.)


### PR DESCRIPTION
## Summary
- replace period-based limit with consecutive-use counter
- add popup setting for number of unprompted uses
- document new behavior and remove hourly/daily/weekly references

## Testing
- `npm test` (fails: Missing script "test")
- `SUPABASE_URL=... SUPABASE_ANON_KEY=... npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1ff682fe0832da94e15f3fcab91d0