### PR TITLE
feat: enable behavior settings

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -16,25 +16,32 @@
     const ALLOW_KEY = `aidetox_${KEY_VERSION}_allow_until_${DOMAIN}`;
     const REASONS_KEY = `aidetox_${KEY_VERSION}_reasons_${DOMAIN}`;
   
-    const TTL = 30 * 1000;           // re-prompt after 30s
-    const MIN_CHARS = 10;            // min reason length
-    const UNLOCK_DELAY = 10 * 1000;  // 10 seconds lock
     const FREE_USES_KEY = 'aidetox_free_uses';
     const USES_BEFORE_PROMPT_KEY = 'aidetox_uses_before_prompt';
     const LIMIT_PERIOD_KEY = 'aidetox_limit_period';
     const LAST_RESET_KEY = 'aidetox_last_reset';
+    const ALWAYS_ASK_KEY = 'aidetox_always_ask';
+    const UNLOCK_DELAY_KEY = 'aidetox_unlock_delay';
+    const MIN_CHARS_KEY = 'aidetox_min_chars';
+
     const settings = await new Promise(resolve => {
       chrome.storage.local.get([
         FREE_USES_KEY,
         USES_BEFORE_PROMPT_KEY,
         LIMIT_PERIOD_KEY,
         LAST_RESET_KEY,
+        ALWAYS_ASK_KEY,
+        UNLOCK_DELAY_KEY,
+        MIN_CHARS_KEY,
       ], resolve);
     });
     let freeUses = settings[FREE_USES_KEY] ?? 0;
     const usesBeforePrompt = settings[USES_BEFORE_PROMPT_KEY] ?? 0;
     const limitPeriod = settings[LIMIT_PERIOD_KEY] || 'hour';
     let lastReset = settings[LAST_RESET_KEY] ?? 0;
+    const MIN_CHARS = settings[MIN_CHARS_KEY] ?? 10;
+    const UNLOCK_DELAY = (settings[UNLOCK_DELAY_KEY] ?? 10) * 1000;
+    const TTL = settings[ALWAYS_ASK_KEY] ? 0 : 30 * 1000;           // re-prompt after 30s unless always ask
     const now = Date.now();
     const periodMs = limitPeriod === 'day' ? 24 * 60 * 60 * 1000 : 60 * 60 * 1000;
     if (now - lastReset >= periodMs) {
@@ -93,7 +100,7 @@
                 <rect class="lock-body" x="6" y="10" width="12" height="10" rx="2" ry="2" fill="currentColor"/>
               </svg>
             </span>
-            <span id="aidetox-yes-label">Proceed in 10</span>
+            <span id="aidetox-yes-label">Proceed in ${UNLOCK_DELAY / 1000}</span>
           </button>
         </div>
       </div>

--- a/src/popup.html
+++ b/src/popup.html
@@ -138,28 +138,28 @@
           </form>
         </div>
 
-        <!-- Behavior (unchanged / coming soon) -->
+        <!-- Behavior -->
         <div class="set-card">
           <div class="set-title">Behavior</div>
           <div class="set-row">
             <label class="switch">
-              <input type="checkbox" id="set-always-ask" disabled />
+              <input type="checkbox" id="set-always-ask" />
               <span class="slider"></span>
             </label>
             <div>
               <div class="set-row-title">Always ask (no 30s buffer)</div>
-              <div class="muted small">Prompt every visit. (Coming soon)</div>
+              <div class="muted small">Prompt every visit.</div>
             </div>
           </div>
           <div class="set-row">
             <div class="set-row-title">Unlock delay</div>
-            <input type="number" id="set-unlock" class="set-input" min="0" step="1" value="10" disabled />
-            <div class="muted small">Seconds before Proceed unlocks. (Coming soon)</div>
+            <input type="number" id="set-unlock" class="set-input" min="0" step="1" value="10" />
+            <div class="muted small">Seconds before Proceed unlocks.</div>
           </div>
           <div class="set-row">
             <div class="set-row-title">Minimum reason length</div>
-            <input type="number" id="set-minchars" class="set-input" min="0" step="1" value="10" disabled />
-            <div class="muted small">Characters required to proceed. (Coming soon)</div>
+            <input type="number" id="set-minchars" class="set-input" min="0" step="1" value="10" />
+            <div class="muted small">Characters required to proceed.</div>
           </div>
         </div>
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -19,34 +19,65 @@ let LB_SCOPE = "global"; // "global" | "friends"
 // Settings keys
 const USES_BEFORE_PROMPT_KEY = "aidetox_uses_before_prompt";
 const LIMIT_PERIOD_KEY = "aidetox_limit_period";
+const ALWAYS_ASK_KEY = "aidetox_always_ask";
+const UNLOCK_DELAY_KEY = "aidetox_unlock_delay";
+const MIN_CHARS_KEY = "aidetox_min_chars";
 
 function loadSettings() {
   chrome.storage.local.get([
     USES_BEFORE_PROMPT_KEY,
     LIMIT_PERIOD_KEY,
+    ALWAYS_ASK_KEY,
+    UNLOCK_DELAY_KEY,
+    MIN_CHARS_KEY,
   ], (res) => {
     const uses = res[USES_BEFORE_PROMPT_KEY] ?? 0;
     const period = res[LIMIT_PERIOD_KEY] || "hour";
+    const alwaysAsk = !!res[ALWAYS_ASK_KEY];
+    const unlock = res[UNLOCK_DELAY_KEY] ?? 10;
+    const minChars = res[MIN_CHARS_KEY] ?? 10;
+
     const usesEl = document.getElementById("set-uses-before");
     const periodEl = document.getElementById("set-limit-period");
+    const alwaysAskEl = document.getElementById("set-always-ask");
+    const unlockEl = document.getElementById("set-unlock");
+    const minCharsEl = document.getElementById("set-minchars");
+
     if (usesEl) usesEl.value = uses;
     if (periodEl) periodEl.value = period;
+    if (alwaysAskEl) alwaysAskEl.checked = alwaysAsk;
+    if (unlockEl) unlockEl.value = unlock;
+    if (minCharsEl) minCharsEl.value = minChars;
   });
 }
 
 function saveSettings() {
   const usesEl = document.getElementById("set-uses-before");
   const periodEl = document.getElementById("set-limit-period");
+  const alwaysAskEl = document.getElementById("set-always-ask");
+  const unlockEl = document.getElementById("set-unlock");
+  const minCharsEl = document.getElementById("set-minchars");
+
   const uses = parseInt(usesEl?.value, 10) || 0;
   const period = periodEl?.value === "day" ? "day" : "hour";
+  const alwaysAsk = !!alwaysAskEl?.checked;
+  const unlock = parseInt(unlockEl?.value, 10) || 0;
+  const minChars = parseInt(minCharsEl?.value, 10) || 0;
+
   chrome.storage.local.set({
     [USES_BEFORE_PROMPT_KEY]: uses,
     [LIMIT_PERIOD_KEY]: period,
+    [ALWAYS_ASK_KEY]: alwaysAsk,
+    [UNLOCK_DELAY_KEY]: unlock,
+    [MIN_CHARS_KEY]: minChars,
   });
 }
 
 document.getElementById("set-uses-before")?.addEventListener("change", saveSettings);
 document.getElementById("set-limit-period")?.addEventListener("change", saveSettings);
+document.getElementById("set-always-ask")?.addEventListener("change", saveSettings);
+document.getElementById("set-unlock")?.addEventListener("change", saveSettings);
+document.getElementById("set-minchars")?.addEventListener("change", saveSettings);
 
 // -------------------------
 // Device ID (for anon/global leaderboards, etc.)


### PR DESCRIPTION
## Summary
- Activate behavior panel settings for always asking, unlock delay, and minimum reason length
- Persist behavior preferences and apply them in the content script

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b208357218832d8296666b8ee300e3