### PR TITLE
Use forest green for main theme

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -82,9 +82,9 @@
   .aidetox-btn:hover { filter: brightness(0.97); }
 
   .aidetox-btn-primary {
-    background: linear-gradient(#4c6ef5,#2b63d9);
+    background: linear-gradient(#388e3c,#2e7d32);
     color: #fff;
-    border: 1px solid #1c44b5;
+    border: 1px solid #1b5e20;
   }
   
   /* Disabled look */

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,7 +1,7 @@
 /* Mid-2010s inspired palette and sharper corners */
 :root{
     --bg:#dfe3e8; --card:#ffffff; --muted:#555; --text:#222; --border:#bfc3c7;
-    --primary:#2b63d9; --danger:#c0392b; --proceed:#2e8b57; --close:#c0392b; --radius:6px;
+    --primary:#2e7d32; --danger:#c0392b; --proceed:#2e8b57; --close:#c0392b; --radius:6px;
   }
   *{ box-sizing:border-box }
   html,body{ width:440px; margin:0; padding:0; }
@@ -10,26 +10,26 @@
   
   /* Header */
   .hdr{ display:flex; justify-content:space-between; align-items:center; padding:12px;
-    background:linear-gradient(#4c6ef5, #2b63d9); color:#fff; border-bottom:1px solid #1d3e91; }
+    background:linear-gradient(#388e3c, #2e7d32); color:#fff; border-bottom:1px solid #1b5e20; }
   .hdr-title{ display:flex; gap:10px; align-items:center }
   .hdr-title h1{ margin:0; font-size:16px }
   .hdr-title .muted{ margin:2px 0 0; font-size:12px; color:#e0e0e0 }
   .hdr-logo{ width:36px; height:36px; display:grid; place-items:center;
-    background:rgba(255,255,255,.25); border:1px solid #1d3e91; border-radius:6px; }
+    background:rgba(255,255,255,.25); border:1px solid #1b5e20; border-radius:6px; }
   .hdr-stats{ display:flex; gap:14px }
-  .stat{ text-align:center } .stat span{ display:block; font-weight:700; font-size:14px } .stat label{ display:block; color:var(--muted); font-size:11px }
+  .stat{ text-align:center } .stat span{ display:block; font-weight:700; font-size:14px } .stat label{ display:block; color:#fff; font-size:11px }
   
   /* Tabs */
   .tabs{ display:flex; gap:8px; padding:10px 12px; background:var(--card); border-bottom:1px solid var(--border); }
   .tab{ padding:7px 12px; border-radius:0; border:1px solid var(--border);
     background:linear-gradient(#f9f9f9, #e0e0e0); cursor:pointer; font-weight:600; color:var(--text); }
-  .tab.is-active{ background:linear-gradient(#4c6ef5, #2b63d9); color:#fff; border-color:#2b63d9; }
+  .tab.is-active{ background:linear-gradient(#388e3c, #2e7d32); color:#fff; border-color:#2e7d32; }
   
   /* Activity controls */
   .controls{ display:grid; grid-template-columns:1fr; gap:8px; padding:12px; }
   .seg{ display:inline-flex; border:1px solid var(--border); border-radius:4px; overflow:hidden; background:var(--card); }
   .seg-btn{ padding:7px 10px; border:0; background:transparent; cursor:pointer; font-weight:600; color:var(--text); }
-  .seg-btn + .seg-btn{ border-left:1px solid var(--border) } .seg-btn.is-active{ background:linear-gradient(#4c6ef5, #2b63d9); color:#fff }
+  .seg-btn + .seg-btn{ border-left:1px solid var(--border) } .seg-btn.is-active{ background:linear-gradient(#388e3c, #2e7d32); color:#fff }
   .search{ width:100%; padding:8px 10px; border:1px solid var(--border); border-radius:10px; background:#fff; color:#111; caret-color:#111; }
   .search::placeholder{ color:#9ca3af } .search:focus{ outline:none; border-color:#9ca3af; box-shadow:0 0 0 3px rgba(156,163,175,.25) }
   .actions{ display:flex; gap:8px }
@@ -64,7 +64,7 @@
   .ranklist{ display:grid; gap:6px; }
   .rankrow{ display:grid; grid-template-columns: 28px 1fr 60px; align-items:center; gap:8px;
     padding:8px 10px; border:1px solid var(--border); border-radius:4px; background:linear-gradient(#fefefe,#e6e6e6); }
-  .rankrow.me{ background:linear-gradient(#eaf2ff,#d2e0ff); border-color:#99b1e6; } /* highlight your row */
+  .rankrow.me{ background:linear-gradient(#eaf7ea,#d2e8d2); border-color:#99c199; } /* highlight your row */
   .ranknum{ font-weight:800; text-align:center; }
   .rankname{ display:flex; align-items:center; gap:8px; }
   .rankname img{ width:16px; height:16px; border-radius:4px }
@@ -85,7 +85,7 @@
   .switch input{ display:none }
   .slider{ position:absolute; inset:0; background:#e5e7eb; border-radius:999px; transition:.2s; }
   .slider:before{ content:''; position:absolute; width:18px; height:18px; left:3px; top:3px; background:#fff; border-radius:50%; transition:.2s; }
-  .switch input:checked + .slider{ background:#2b63d9 } .switch input:checked + .slider:before{ transform:translateX(20px) }
+  .switch input:checked + .slider{ background:#2e7d32 } .switch input:checked + .slider:before{ transform:translateX(20px) }
   
   /* Footer + helpers */
   .foot{ padding:8px 12px 12px; font-size:11px; }
@@ -108,7 +108,7 @@
     color: var(--text);
   }
   .tab.is-active {
-    background: #111827;
+    background: #2e7d32;
     color: #fff;
   }
   
@@ -133,7 +133,7 @@
     background: transparent;
   }
   .lb-controls .seg-btn.is-active {
-    background: #111827;
+    background: #2e7d32;
     color: #fff;
   }
   
@@ -167,8 +167,8 @@
     }
     .ranklist .row + .row { margin-top: 4px; }
     .ranklist .row.me {
-      background: linear-gradient(#eaf2ff,#d2e0ff);
-      border: 1px solid #99b1e6;
+      background: linear-gradient(#eaf7ea,#d2e8d2);
+      border: 1px solid #99c199;
     }
     .ranklist .rank { font-weight: 700; width: 28px; text-align: right; }
     .ranklist .name {


### PR DESCRIPTION
## Summary
- switch primary color and header gradient to forest green
- lighten leaderboard and tab accents to match new palette
- make header stats labels white for better readability

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b212350af4832da346f9ab40bf56ec