### PR TITLE
Use extension storage for logging reasons

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -196,12 +196,14 @@ import { isGoodReason } from './reasonCheck.js';
         return;
       }
   
-      // per-domain local log (optional, keep if you like)
+      // per-domain log stored in extension storage (not page localStorage)
       try {
         const entry = { at: new Date().toISOString(), reason };
-        const arr = JSON.parse(localStorage.getItem(REASONS_KEY) || '[]');
-        arr.push(entry);
-        localStorage.setItem(REASONS_KEY, JSON.stringify(arr));
+        chrome.storage.local.get([REASONS_KEY], (result) => {
+          const arr = result[REASONS_KEY] || [];
+          arr.push(entry);
+          chrome.storage.local.set({ [REASONS_KEY]: arr });
+        });
       } catch {}
   
       // central log in chrome.storage


### PR DESCRIPTION
## Summary
- Store user-provided reasons in `chrome.storage.local` instead of page `localStorage`
- Prevent visited pages from accessing logged reasons

## Testing
- `npm test` *(fails: Missing script "test")*
- `SUPABASE_URL=... SUPABASE_ANON_KEY=... npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2159058f8832d971f13cf748e38c5