### PR TITLE
feat: add friends tab with requests

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -180,5 +180,15 @@
       white-space: nowrap;
     }
     .ranklist .val { font-weight: 600; color: #111; }
+
+/* Friends */
+.friends{ padding:12px; display:grid; gap:12px; }
+.friend-card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 2px 6px rgba(0,0,0,.2); padding:12px; }
+.friend-title{ font-weight:700; margin-bottom:8px; }
+.friend-row{ display:flex; align-items:center; gap:8px; margin:8px 0; }
+.friend-list{ list-style:none; margin:0; padding:0; display:grid; gap:6px; }
+.friend-list li{ display:flex; justify-content:space-between; align-items:center; padding:6px 8px; border:1px solid var(--border); border-radius:4px; background:linear-gradient(#fefefe,#e6e6e6); }
+.friend-list li .actions{ display:flex; gap:6px; }
+.btn-sm{ padding:4px 6px; font-size:12px; }
   
   

--- a/src/popup.html
+++ b/src/popup.html
@@ -23,8 +23,9 @@
 
     <nav class="tabs">
       <button class="tab is-active" data-tab="activity">Activity</button>
-      <button class="tab" data-tab="leaderboards">Leaderboards</button>
       <button class="tab" data-tab="settings">Settings</button>
+      <button class="tab" data-tab="friends">Friends</button>
+      <button class="tab" data-tab="leaderboards">Leaderboards</button>
     </nav>
 
     <!-- Activity -->
@@ -42,6 +43,28 @@
         </div>
       </section>
       <main id="list" class="list"></main>
+    </section>
+
+    <!-- Friends -->
+    <section id="tab-friends" class="hidden">
+      <div class="friends">
+        <div class="friend-card">
+          <div class="friend-title">Add Friend</div>
+          <div class="friend-row">
+            <input id="add-friend-username" class="set-input-wide" placeholder="username" />
+            <button id="add-friend-btn" class="btn btn-secondary">Add</button>
+            <span id="add-friend-msg" class="muted small"></span>
+          </div>
+        </div>
+        <div class="friend-card">
+          <div class="friend-title">Friend Requests</div>
+          <ul id="friend-requests" class="friend-list"></ul>
+        </div>
+        <div class="friend-card">
+          <div class="friend-title">Friends</div>
+          <ul id="friends-list" class="friend-list"></ul>
+        </div>
+      </div>
     </section>
 
     <!-- Leaderboards -->

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -1,0 +1,10 @@
+-- Friend requests for pending friendships
+CREATE TABLE public.friend_requests (
+  requester uuid NOT NULL,
+  requestee uuid NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT friend_requests_pkey PRIMARY KEY (requester, requestee),
+  CONSTRAINT friend_requests_requester_fkey FOREIGN KEY (requester) REFERENCES auth.users(id),
+  CONSTRAINT friend_requests_requestee_fkey FOREIGN KEY (requestee) REFERENCES auth.users(id)
+);
+


### PR DESCRIPTION
## Summary
- add dedicated Friends tab with list, requests, and add-friend form
- support friend request workflow via Supabase
- create `friend_requests` table schema and supporting styles

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'addListener'))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4c0e3de50832d9c4e36f5eda1bc4b