### PR TITLE
Add statistics helper for popup activity log

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -289,6 +289,24 @@ function escapeCsv(v) {
   return /[",\n]/.test(s) ? `"${s}"` : s;
 }
 
+function updateStats(log = []) {
+  const totalEl = document.getElementById("stat-total");
+  const proceedEl = document.getElementById("stat-proceed");
+  const closeEl = document.getElementById("stat-close");
+
+  const total = log.length;
+  let proceed = 0;
+  let close = 0;
+  for (const entry of log) {
+    if (entry.event === "proceed") proceed++;
+    else if (entry.event === "close") close++;
+  }
+
+  if (totalEl) totalEl.textContent = String(total);
+  if (proceedEl) proceedEl.textContent = String(proceed);
+  if (closeEl) closeEl.textContent = String(close);
+}
+
 function renderTable(log, filter = "all") {
   const wrap = $("#list");
   if (!wrap) return;
@@ -363,7 +381,9 @@ function renderTable(log, filter = "all") {
 function loadAndRender(filter = "all") {
   chrome.runtime.sendMessage({ type: "AIDETOX_GET_LOG" }, (res) => {
     if (!res?.ok) return;
-    renderTable(res.log || [], filter);
+    const log = res.log || [];
+    updateStats(log);
+    renderTable(log, filter);
   });
 }
 

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -12,6 +12,9 @@ const chromeStub = {
         listener = cb;
       },
     },
+    onInstalled: { addListener() {} },
+    onStartup: { addListener() {} },
+    onSuspend: { addListener() {} },
   },
   storage: {
     local: {


### PR DESCRIPTION
## Summary
- display total, proceed, and close counts by adding `updateStats` helper and integrating it into popup log rendering
- extend background tests with additional chrome runtime stubs so they run successfully

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4c9a66768832d924a7b58a60d7b40