### PR TITLE
Filter leaderboard entries without identities

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -104,6 +104,7 @@ CREATE OR REPLACE FUNCTION "public"."lb_noassist_streak"("p_since" timestamp wit
     )::bigint as value
   from public.events e
   where at >= p_since
+    and e.profile_id is not null
   group by e.profile_id
   order by value desc
   limit 100;
@@ -123,6 +124,7 @@ CREATE OR REPLACE FUNCTION "public"."lb_offgrid_streak"("p_since" timestamp with
          )::bigint AS value
   FROM public.events
   WHERE at >= p_since
+    AND profile_id IS NOT NULL
   GROUP BY profile_id
   ORDER BY value DESC
   LIMIT 100;

--- a/supabase/functions/leaderboards/index.ts
+++ b/supabase/functions/leaderboards/index.ts
@@ -129,9 +129,10 @@ serve(async (req: Request) => {
     // Shape + rank (names are resolved later)
     let entries = (data ?? [])
       .map((r: any) => ({
-        id: String(r.identity),
+        id: r.identity ? String(r.identity) : "",
         val: Number(r.value) || 0,
       }))
+      .filter((e: any) => e.id)
       .sort((a: any, b: any) => b.val - a.val);
 
     if (scope === "friends" && friendIds) {

--- a/supabase/migrations/20240510120000__filter_null_profile_id.sql
+++ b/supabase/migrations/20240510120000__filter_null_profile_id.sql
@@ -1,0 +1,53 @@
+-- Add profile_id IS NOT NULL filters to leaderboard functions
+CREATE OR REPLACE FUNCTION "public"."lb_noassist_streak"("p_since" timestamp with time zone DEFAULT '1970-01-01 00:00:00+00'::timestamp with time zone)
+RETURNS TABLE("identity" "uuid", "value" bigint)
+LANGUAGE "sql" STABLE
+AS $$
+  select
+    e.profile_id as identity,
+    date_part(
+      'day',
+      now() - coalesce(
+        max(at) filter (
+          where domain = any (
+            array[
+              'chatgpt.com',
+              'chat.openai.com',
+              'claude.ai',
+              'gemini.google.com',
+              'perplexity.ai',
+              'copilot.microsoft.com',
+              'poe.com',
+              'character.ai',
+              'huggingface.co',
+              'openrouter.ai'
+            ]  -- AI domains
+          )
+        ),
+        p_since
+      )
+    )::bigint as value
+  from public.events e
+  where at >= p_since
+    and e.profile_id is not null
+  group by e.profile_id
+  order by value desc
+  limit 100;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."lb_offgrid_streak"("p_since" timestamp with time zone DEFAULT '1970-01-01 00:00:00+00'::timestamp with time zone)
+RETURNS TABLE("identity" "uuid", "value" bigint)
+LANGUAGE "sql" STABLE
+AS $$
+  SELECT profile_id AS identity,
+         DATE_PART(
+           'day',
+           NOW() - COALESCE(MAX(at) FILTER (WHERE event = 'proceed'), p_since)
+         )::bigint AS value
+  FROM public.events
+  WHERE at >= p_since
+    AND profile_id IS NOT NULL
+  GROUP BY profile_id
+  ORDER BY value DESC
+  LIMIT 100;
+$$;


### PR DESCRIPTION
## Summary
- Filter out leaderboard entries with null identities before resolving profile names
- Add database migration and schema updates so `lb_noassist_streak` and `lb_offgrid_streak` ignore events lacking a profile_id

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ca384514832da1885d2cad9e9c01