### PR TITLE
Improve auth feedback for sign up and logout

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -243,8 +243,9 @@ $("#form-signup")?.addEventListener("submit", async (e) => {
   if (data?.user) {
     await ensureProfile(data.user);
   }
-
-  msg.textContent = "Account created! Check your email if verification is required.";
+  // Notify the user that a confirmation email has been sent
+  msg.textContent = "";
+  alert("Confirmation email sent. Please check your inbox.");
   await renderAuthState();
 });
 
@@ -278,7 +279,13 @@ $("#form-login")?.addEventListener("submit", async (e) => {
 // Log out
 // -------------------------
 $("#btn-logout")?.addEventListener("click", async () => {
-  await supabase.auth.signOut();
+  const { error } = await supabase.auth.signOut();
+  if (error) {
+    console.error("Sign out failed:", error.message);
+    return;
+  }
+  // Clear the stored session so the UI updates immediately
+  storeSession(null);
   await renderAuthState();
 });
 


### PR DESCRIPTION
## Summary
- Show a confirmation email alert after signing up
- Update UI immediately on logout by clearing stored session and handling sign-out errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c7b28318832d898a4530779a2845