### PR TITLE
Revamp activity tab with daily usage summary

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -25,35 +25,23 @@
     background:linear-gradient(#f9f9f9, #e0e0e0); cursor:pointer; font-weight:600; color:var(--text); }
   .tab.is-active{ background:linear-gradient(#388e3c, #2e7d32); color:#fff; border-color:#2e7d32; }
   
-  /* Activity controls */
-  .controls{ display:grid; grid-template-columns:1fr; gap:8px; padding:12px; }
-  .seg{ display:inline-flex; border:1px solid var(--border); border-radius:4px; overflow:hidden; background:var(--card); }
-  .seg-btn{ padding:7px 10px; border:0; background:transparent; cursor:pointer; font-weight:600; color:var(--text); }
-  .seg-btn + .seg-btn{ border-left:1px solid var(--border) } .seg-btn.is-active{ background:linear-gradient(#388e3c, #2e7d32); color:#fff }
-  .search{ width:100%; padding:8px 10px; border:1px solid var(--border); border-radius:10px; background:#fff; color:#111; caret-color:#111; }
-  .search::placeholder{ color:#9ca3af } .search:focus{ outline:none; border-color:#9ca3af; box-shadow:0 0 0 3px rgba(156,163,175,.25) }
-  .actions{ display:flex; gap:8px }
-  .btn{ padding:7px 10px; border-radius:4px; border:1px solid var(--border);
-    background:linear-gradient(#fefefe,#dedede); cursor:pointer; font-weight:600; }
-  .btn:hover{ filter:brightness(.97) }
-  .btn-secondary{ background:linear-gradient(#f9f9f9,#e2e2e2); }
-  .btn-danger{ background:linear-gradient(#fceaea,#f9bebe); border-color:#e99; color:var(--danger) }
-  
-  /* Activity cards */
-  .list{ padding:12px; max-height:420px; overflow:auto; }
-  .group{ margin-bottom:12px; } .group h3{ margin:0 0 8px; font-size:12px; color:var(--muted); font-weight:600; }
-  .card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); padding:10px;
-    box-shadow:0 2px 6px rgba(0,0,0,.2); display:grid; grid-template-columns:auto 1fr auto; gap:10px; align-items:start; }
-  .card + .card{ margin-top:8px } .card .bar{ width:4px; height:100%; border-radius:8px; background:#ddd; }
-  .card.proceed .bar{ background:var(--proceed) } .card.close .bar{ background:var(--close) }
-  .meta{ display:flex; flex-wrap:wrap; gap:6px 10px; align-items:center; color:var(--muted); font-size:12px; }
-  .meta .dot{ width:4px; height:4px; border-radius:50%; background:#d1d5db }
-  .badge{ display:inline-flex; align-items:center; gap:6px; padding:3px 8px; border:1px solid var(--border); border-radius:999px; background:#f8fafc; color:#374151; }
-  .badge img{ width:14px; height:14px; border-radius:4px }
-  .title{ font-weight:700; margin:2px 0 6px; }
-  .reason{ color:#374151; white-space:pre-wrap; margin:0; }
-  .reason.collapsed{ display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
-  .card-actions{ display:flex; gap:6px } .link{ font-size:12px; color:#2563eb; text-decoration:none; } .link:hover{ text-decoration:underline }
+    /* Activity summary */
+    .activity-summary{ text-align:center; padding:40px 0; }
+    .today-count{ font-size:72px; font-weight:700; margin-bottom:8px; }
+    .activity-stats{ display:grid; gap:4px; font-size:14px; color:var(--muted); }
+
+    .seg{ display:inline-flex; border:1px solid var(--border); border-radius:4px; overflow:hidden; background:var(--card); }
+    .seg-btn{ padding:7px 10px; border:0; background:transparent; cursor:pointer; font-weight:600; color:var(--text); }
+    .seg-btn + .seg-btn{ border-left:1px solid var(--border) }
+    .seg-btn.is-active{ background:linear-gradient(#388e3c, #2e7d32); color:#fff }
+
+    /* Buttons */
+    .btn{ padding:7px 10px; border-radius:4px; border:1px solid var(--border);
+      background:linear-gradient(#fefefe,#dedede); cursor:pointer; font-weight:600; }
+    .btn:hover{ filter:brightness(.97) }
+    .btn-secondary{ background:linear-gradient(#f9f9f9,#e2e2e2); }
+    .btn-danger{ background:linear-gradient(#fceaea,#f9bebe); border-color:#e99; color:var(--danger) }
+    .actions{ display:flex; gap:8px }
   
   /* Leaderboards */
   .lb-controls{ padding:12px; display:flex; justify-content:space-between; align-items:center; }

--- a/src/popup.html
+++ b/src/popup.html
@@ -30,19 +30,14 @@
 
     <!-- Activity -->
     <section id="tab-activity">
-      <section class="controls">
-        <div class="seg">
-          <button class="seg-btn is-active" data-filter="all">All</button>
-          <button class="seg-btn" data-filter="proceed">Proceed</button>
-          <button class="seg-btn" data-filter="close">Closed</button>
+      <div class="activity-summary">
+        <div id="uses-today" class="today-count">0</div>
+        <div class="activity-stats">
+          <div>Uses this week: <span id="uses-week">0</span></div>
+          <div>Uses this month: <span id="uses-month">0</span></div>
+          <div>Longest streak: <span id="longest-streak">0</span> days</div>
         </div>
-        <input id="search" class="search" placeholder="Search reasons, domains…" />
-        <div class="actions">
-          <button id="export" class="btn btn-secondary">Export CSV</button>
-          <button id="clear" class="btn btn-danger">Clear</button>
-        </div>
-      </section>
-      <main id="list" class="list"></main>
+      </div>
     </section>
 
     <!-- Leaderboards -->

--- a/src/popup.js
+++ b/src/popup.js
@@ -285,17 +285,6 @@ $("#btn-logout")?.addEventListener("click", async () => {
 // -------------------------
 // Activity Tab
 // -------------------------
-function fmtTable(ts) {
-  try { return new Date(ts).toLocaleString(); } catch { return ""; }
-}
-function fmtISO(ts) {
-  try { return new Date(ts).toISOString(); } catch { return ""; }
-}
-function escapeCsv(v) {
-  if (v == null) return "";
-  const s = String(v).replace(/"/g, '""');
-  return /[",\n]/.test(s) ? `"${s}"` : s;
-}
 
 function updateStats(log = []) {
   const totalEl = document.getElementById("stat-total");
@@ -315,131 +304,58 @@ function updateStats(log = []) {
   if (closeEl) closeEl.textContent = String(close);
 }
 
-function renderTable(log, filter = "all") {
-  const wrap = $("#list");
-  if (!wrap) return;
 
-  const rows = filter === "all" ? log : log.filter(e => e.event === filter);
+function calcUsageStats(log = []) {
+  const msDay = 24 * 60 * 60 * 1000;
+  const today = new Date();
+  const startOfDay = d => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const todayStart = startOfDay(today);
+  const weekStart = new Date(todayStart - 6 * msDay);
+  const monthStart = new Date(todayStart - 29 * msDay);
 
-  wrap.innerHTML = "";
-
-  if (!rows.length) {
-    const empty = document.createElement("div");
-    empty.className = "empty";
-    empty.textContent = "No entries yet.";
-    wrap.appendChild(empty);
-    return;
+  let dayCount = 0, weekCount = 0, monthCount = 0;
+  const days = [];
+  for (const entry of log) {
+    if (entry.event !== "proceed") continue;
+    const at = new Date(entry.at);
+    if (at >= todayStart) dayCount++;
+    if (at >= weekStart) weekCount++;
+    if (at >= monthStart) monthCount++;
+    days.push(startOfDay(at));
   }
-
-  rows.forEach((e) => {
-    const card = document.createElement("div");
-    card.className = `card ${e.event}`;
-
-    const bar = document.createElement("div");
-    bar.className = "bar";
-    card.appendChild(bar);
-
-    const main = document.createElement("div");
-
-    const title = document.createElement("div");
-    title.className = "title";
-    title.textContent = e.domain || "Unknown domain";
-    main.appendChild(title);
-
-    const reason = document.createElement("p");
-    reason.className = "reason";
-    reason.textContent = e.reason ? e.reason : "—";
-    main.appendChild(reason);
-
-    const meta = document.createElement("div");
-    meta.className = "meta";
-
-    const spanTime = document.createElement("span");
-    spanTime.textContent = fmtTable(e.at);
-    meta.appendChild(spanTime);
-
-    const spanDot = document.createElement("span");
-    spanDot.className = "dot";
-    meta.appendChild(spanDot);
-
-    const spanHost = document.createElement("span");
-    spanHost.className = "muted";
-    spanHost.textContent = e.url ? new URL(e.url).hostname : "";
-    meta.appendChild(spanHost);
-
-    main.appendChild(meta);
-    card.appendChild(main);
-
-    const actions = document.createElement("div");
-    actions.className = "card-actions";
-
-    const link = document.createElement("a");
-    link.className = "link";
-    link.href = e.url || "#";
-    link.target = "_blank";
-    link.textContent = "Open";
-    actions.appendChild(link);
-
-    card.appendChild(actions);
-
-    wrap.appendChild(card);
-  });
+  days.sort((a,b) => a - b);
+  let longest = 0;
+  for (let i = 1; i < days.length; i++) {
+    const gap = Math.floor((days[i] - days[i-1]) / msDay) - 1;
+    if (gap > longest) longest = gap;
+  }
+  if (days.length) {
+    const gap = Math.floor((todayStart - days[days.length-1]) / msDay) - 1;
+    if (gap > longest) longest = gap;
+  }
+  return { today: dayCount, week: weekCount, month: monthCount, longest: Math.max(longest,0) };
 }
 
-function loadAndRender(filter = "all") {
+function renderActivitySummary(log = []) {
+  const { today, week, month, longest } = calcUsageStats(log);
+  const todayEl = document.getElementById("uses-today");
+  const weekEl = document.getElementById("uses-week");
+  const monthEl = document.getElementById("uses-month");
+  const streakEl = document.getElementById("longest-streak");
+  if (todayEl) todayEl.textContent = String(today);
+  if (weekEl) weekEl.textContent = String(week);
+  if (monthEl) monthEl.textContent = String(month);
+  if (streakEl) streakEl.textContent = String(longest);
+}
+
+function loadAndRender() {
   chrome.runtime.sendMessage({ type: "AIDETOX_GET_LOG" }, (res) => {
     if (!res?.ok) return;
     const log = res.log || [];
     updateStats(log);
-    renderTable(log, filter);
+    renderActivitySummary(log);
   });
 }
-
-// Segmented filter buttons
-$$(".seg-btn[data-filter]").forEach(btn => {
-  btn.addEventListener("click", () => {
-    $$(".seg-btn[data-filter]").forEach(b => b.classList.remove("is-active"));
-    btn.classList.add("is-active");
-    loadAndRender(btn.dataset.filter);
-  });
-});
-
-// Export / Clear
-$("#clear")?.addEventListener("click", () => {
-  chrome.runtime.sendMessage({ type: "AIDETOX_CLEAR_LOG" }, () => loadAndRender());
-});
-$("#export")?.addEventListener("click", () => {
-  chrome.runtime.sendMessage({ type: "AIDETOX_GET_LOG" }, async (res) => {
-    if (!res?.ok) return;
-    const rows = res.log || [];
-    const header = ["time","event","domain","url","reason","unlock_delay_ms"];
-    const csv = [
-      header.join(","),
-      ...rows.map(e => [
-        escapeCsv(fmtISO(e.at)),
-        escapeCsv(e.event),
-        escapeCsv(e.domain || ""),
-        escapeCsv(e.url || ""),
-        escapeCsv(e.reason || ""),
-        escapeCsv(e.unlock_delay_ms || "")
-      ].join(","))
-    ].join("\n");
-
-    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    if (chrome.downloads?.download) {
-      chrome.downloads.download(
-        { url, filename: `aidetox_log_${Date.now()}.csv`, saveAs: true },
-        () => setTimeout(() => URL.revokeObjectURL(url), 5000)
-      );
-    } else {
-      const a = document.createElement("a");
-      a.href = url; a.download = `aidetox_log_${Date.now()}.csv`;
-      document.body.appendChild(a); a.click();
-      setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 0);
-    }
-  });
-});
 
 // -------------------------
 // Leaderboards


### PR DESCRIPTION
## Summary
- Replace activity tab with simplified summary showing today's AI use and weekly/monthly totals plus longest streak without use
- Add styling for new activity summary layout
- Compute and render usage statistics in popup script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c88f3138832db8d1397353946548