### PR TITLE
feat: make daily goal configurable

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -197,6 +197,11 @@
               <div class="muted small">Warn on vague reasons.</div>
             </div>
           </div>
+          <div class="set-row">
+            <div class="set-row-title">Daily uses goal</div>
+            <input type="number" id="set-daily-goal" class="set-input" min="1" step="1" value="10" />
+            <div class="muted small">Target uses per day.</div>
+          </div>
         </div>
 
         <!-- Unprompted uses setting -->


### PR DESCRIPTION
## Summary
- allow users to set a daily usage goal in the Settings page
- persist daily goal and use stored value for activity ring

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9d550a960832dbfaedf7ef6ad9be2