### PR TITLE
refactor: integrate off-grid leaderboard into friends tab

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -74,46 +74,6 @@ $$;
 
 ALTER FUNCTION "public"."forbid_username_change"() OWNER TO "postgres";
 
-
-CREATE OR REPLACE FUNCTION "public"."lb_noassist_streak"("p_since" timestamp with time zone DEFAULT '1970-01-01 00:00:00+00'::timestamp with time zone) RETURNS TABLE("identity" "uuid", "value" bigint)
-    LANGUAGE "sql" STABLE
-    AS $$
-  select
-    e.profile_id as identity,
-    date_part(
-      'day',
-      now() - coalesce(
-        max(at) filter (
-          where domain = any (
-            array[
-              'chatgpt.com',
-              'chat.openai.com',
-              'claude.ai',
-              'gemini.google.com',
-              'perplexity.ai',
-              'copilot.microsoft.com',
-              'poe.com',
-              'character.ai',
-              'huggingface.co',
-              'openrouter.ai'
-            ]  -- AI domains
-          )
-        ),
-        p_since
-      )
-    )::bigint as value
-  from public.events e
-  where at >= p_since
-    and e.profile_id is not null
-  group by e.profile_id
-  order by value desc
-  limit 100;
-$$;
-
-
-ALTER FUNCTION "public"."lb_noassist_streak"("p_since" timestamp with time zone) OWNER TO "postgres";
-
-
 CREATE OR REPLACE FUNCTION "public"."lb_offgrid_streak"("p_since" timestamp with time zone DEFAULT '1970-01-01 00:00:00+00'::timestamp with time zone) RETURNS TABLE("identity" "uuid", "value" bigint)
     LANGUAGE "sql" STABLE
     AS $$
@@ -133,21 +93,6 @@ $$;
 
 ALTER FUNCTION "public"."lb_offgrid_streak"("p_since" timestamp with time zone) OWNER TO "postgres";
 
-
-CREATE OR REPLACE FUNCTION "public"."lb_saves"("p_since" timestamp with time zone) RETURNS TABLE("identity" "uuid", "value" bigint)
-    LANGUAGE "sql" STABLE
-    AS $$
-  SELECT profile_id AS identity,
-         COUNT(*)::bigint AS value
-  FROM public.events
-  WHERE event = 'close' AND at >= p_since
-  GROUP BY profile_id
-  ORDER BY value DESC
-  LIMIT 100;
-$$;
-
-
-ALTER FUNCTION "public"."lb_saves"("p_since" timestamp with time zone) OWNER TO "postgres";
 
 SET default_tablespace = '';
 
@@ -560,9 +505,6 @@ GRANT ALL ON FUNCTION "public"."forbid_username_change"() TO "service_role";
 
 
 
-GRANT ALL ON FUNCTION "public"."lb_noassist_streak"("p_since" timestamp with time zone) TO "anon";
-GRANT ALL ON FUNCTION "public"."lb_noassist_streak"("p_since" timestamp with time zone) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."lb_noassist_streak"("p_since" timestamp with time zone) TO "service_role";
 
 
 
@@ -572,9 +514,6 @@ GRANT ALL ON FUNCTION "public"."lb_offgrid_streak"("p_since" timestamp with time
 
 
 
-GRANT ALL ON FUNCTION "public"."lb_saves"("p_since" timestamp with time zone) TO "anon";
-GRANT ALL ON FUNCTION "public"."lb_saves"("p_since" timestamp with time zone) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."lb_saves"("p_since" timestamp with time zone) TO "service_role";
 
 
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -23,7 +23,6 @@
 
     <nav class="tabs">
       <button class="tab is-active" data-tab="activity">Activity</button>
-      <button class="tab" data-tab="leaderboards">Leaderboards</button>
       <button class="tab" data-tab="friends">Friends</button>
       <button class="tab" data-tab="settings">Settings</button>
     </nav>
@@ -45,54 +44,28 @@
       </div>
     </section>
 
-    <!-- Leaderboards -->
-    <section id="tab-leaderboards" class="hidden">
+    <!-- Friends -->
+    <section id="tab-friends" class="hidden">
       <div class="lb-controls">
         <div class="seg">
           <button class="seg-btn seg-scope is-active" data-scope="global">Global</button>
           <button class="seg-btn seg-scope" data-scope="friends">Friends</button>
         </div>
-        <div class="muted small" id="lb-note">Showing mock data until you connect.</div>
+        <div class="muted small" id="lb-note">Showing global data.</div>
       </div>
 
       <div class="boards">
-        <!-- No-Assist Streak -->
         <div class="board-card">
           <div class="board-head">
-            <div class="board-title">No-Assist Streak</div>
-            <div class="board-sub">Didn't visit AI sites</div>
-          </div>
-          <div class="board-body">
-            <div id="lb-noai-list" class="ranklist"></div>
-          </div>
-        </div>
-
-        <!-- Off-Grid Streak -->
-        <div class="board-card">
-          <div class="board-head">
-            <div class="board-title">Off-Grid Streak</div>
+            <div class="board-title">Days without AI</div>
             <div class="board-sub">Didn’t open AI sites</div>
           </div>
           <div class="board-body">
             <div id="lb-novisit-list" class="ranklist"></div>
           </div>
         </div>
-
-        <!-- Detox Saves (new metric) -->
-        <div class="board-card">
-          <div class="board-head">
-            <div class="board-title">Detox Saves</div>
-            <div class="board-sub">Clicked “No” on the prompt</div>
-          </div>
-          <div class="board-body">
-            <div id="lb-saves-list" class="ranklist"></div>
-          </div>
-        </div>
       </div>
-    </section>
 
-    <!-- Friends -->
-    <section id="tab-friends" class="hidden">
       <div class="friends">
         <div class="friend-card">
           <div class="friend-title">Add Friend</div>

--- a/supabase/functions/leaderboards/index.ts
+++ b/supabase/functions/leaderboards/index.ts
@@ -1,7 +1,5 @@
 // supabase/functions/leaderboards/index.ts
-// Leaderboards API -> wraps Postgres RPCs:
-//   - lb_saves
-//   - lb_noassist_streak
+// Leaderboards API -> wraps Postgres RPC:
 //   - lb_offgrid_streak
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
@@ -68,8 +66,8 @@ serve(async (req: Request) => {
       return new Response("Method Not Allowed", { status: 405, headers: CORS });
     }
 
-    // Validate metric
-    if (!["noai", "novisit", "saves"].includes(String(metric))) {
+    // Validate metric (only novisit supported)
+    if (String(metric) !== "novisit") {
       return err("invalid_metric", 400, { metric });
     }
 
@@ -112,15 +110,7 @@ serve(async (req: Request) => {
     const since = new Date();
     since.setMonth(since.getMonth() - 6);
 
-    // Map metric -> RPC
-    const rpcName =
-      metric === "saves"
-        ? "lb_saves"
-        : metric === "noai"
-        ? "lb_noassist_streak"
-        : "lb_offgrid_streak";
-
-    const { data, error } = await supabase.rpc(rpcName, {
+    const { data, error } = await supabase.rpc("lb_offgrid_streak", {
       p_since: since.toISOString(),
     });
 

--- a/supabase/migrations/20240515150000__drop_unused_leaderboards.sql
+++ b/supabase/migrations/20240515150000__drop_unused_leaderboards.sql
@@ -1,0 +1,3 @@
+-- Remove unused leaderboard functions
+DROP FUNCTION IF EXISTS public.lb_noassist_streak(p_since timestamp with time zone);
+DROP FUNCTION IF EXISTS public.lb_saves(p_since timestamp with time zone);


### PR DESCRIPTION
## Summary
- remove the standalone leaderboards tab
- show "Days without AI" leaderboard at top of friends tab
- drop unused leaderboard RPCs and references

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d5b0e54c832db9d213cf1bc72d03