### PR TITLE
Remove standalone leaderboard tab and drop unused functions

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -23,7 +23,6 @@
 
     <nav class="tabs">
       <button class="tab is-active" data-tab="activity">Activity</button>
-      <button class="tab" data-tab="leaderboards">Leaderboards</button>
       <button class="tab" data-tab="friends">Friends</button>
       <button class="tab" data-tab="settings">Settings</button>
     </nav>
@@ -45,32 +44,20 @@
       </div>
     </section>
 
-    <!-- Leaderboards -->
-    <section id="tab-leaderboards" class="hidden">
-      <div class="lb-controls">
-        <div class="seg">
-          <button class="seg-btn seg-scope is-active" data-scope="global">Global</button>
-          <button class="seg-btn seg-scope" data-scope="friends">Friends</button>
-        </div>
-        <div class="muted small" id="lb-note">Showing mock data until you connect.</div>
-      </div>
-
-      <div class="boards">
-        <!-- No-Assist Streak -->
-        <div class="board-card">
-          <div class="board-head">
-            <div class="board-title">No-Assist Streak</div>
-            <div class="board-sub">Didn't visit AI sites</div>
+    <!-- Friends -->
+    <section id="tab-friends" class="hidden">
+      <div class="friends">
+        <div class="lb-controls">
+          <div class="seg">
+            <button class="seg-btn seg-scope is-active" data-scope="global">Global</button>
+            <button class="seg-btn seg-scope" data-scope="friends">Friends</button>
           </div>
-          <div class="board-body">
-            <div id="lb-noai-list" class="ranklist"></div>
-          </div>
+          <div class="muted small" id="lb-note">Showing mock data until you connect.</div>
         </div>
 
-        <!-- Off-Grid Streak -->
         <div class="board-card">
           <div class="board-head">
-            <div class="board-title">Off-Grid Streak</div>
+            <div class="board-title">Days without AI</div>
             <div class="board-sub">Didn’t open AI sites</div>
           </div>
           <div class="board-body">
@@ -78,22 +65,6 @@
           </div>
         </div>
 
-        <!-- Detox Saves (new metric) -->
-        <div class="board-card">
-          <div class="board-head">
-            <div class="board-title">Detox Saves</div>
-            <div class="board-sub">Clicked “No” on the prompt</div>
-          </div>
-          <div class="board-body">
-            <div id="lb-saves-list" class="ranklist"></div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Friends -->
-    <section id="tab-friends" class="hidden">
-      <div class="friends">
         <div class="friend-card">
           <div class="friend-title">Add Friend</div>
           <div class="friend-row">

--- a/src/popup.js
+++ b/src/popup.js
@@ -452,7 +452,7 @@ function loadAndRender() {
 }
 
 // -------------------------
-// Leaderboards
+// Leaderboard
 // -------------------------
 async function getLeaderboard(metric, scope = LB_SCOPE) {
   const device_id = await getDeviceId();
@@ -464,7 +464,7 @@ async function getLeaderboard(metric, scope = LB_SCOPE) {
   }
 
   const url = new URL(FN_LEADERBOARDS);
-  url.searchParams.set("metric", metric);      // "noai" | "novisit" | "saves"
+  url.searchParams.set("metric", metric);      // "novisit"
   url.searchParams.set("scope", scope);        // "global" | "friends"
   if (device_id) url.searchParams.set("device_id", device_id);
 
@@ -520,18 +520,14 @@ function renderRanklist(containerId, lb) {
   wrap.innerHTML = rows + meRow;
 }
 
-async function renderLeaderboards() {
-  const [lb1, lb2, lb3] = await Promise.all([
-    getLeaderboard("noai", LB_SCOPE),
-    getLeaderboard("novisit", LB_SCOPE),
-    getLeaderboard("saves", LB_SCOPE),
-  ]);
-  renderRanklist("lb-noai-list", lb1);
-  renderRanklist("lb-novisit-list", lb2);
-  renderRanklist("lb-saves-list", lb3);
+async function renderOffGridLeaderboard() {
+  const lb = await getLeaderboard("novisit", LB_SCOPE);
+  renderRanklist("lb-novisit-list", lb);
 }
 
 async function renderFriendsTab() {
+  await renderOffGridLeaderboard();
+
   const listEl = $("#friends-list");
   const reqEl = $("#friend-requests");
   const msgEl = $("#add-friend-msg");
@@ -622,7 +618,7 @@ $$(".seg-scope").forEach(btn => {
     note.textContent = LB_SCOPE === "friends"
       ? "Friends leaderboard requires login."
       : "Showing global data.";
-    await renderLeaderboards();
+    await renderOffGridLeaderboard();
   });
 });
 
@@ -638,8 +634,7 @@ $$(".tab").forEach(tabBtn => {
     const target = "tab-" + tabBtn.dataset.tab;
     document.getElementById(target).classList.remove("hidden");
 
-    if (target === "tab-leaderboards") renderLeaderboards();
-    else if (target === "tab-activity") loadAndRender();
+    if (target === "tab-activity") loadAndRender();
     else if (target === "tab-settings") {
       renderAuthState();
       loadSettings();

--- a/supabase/functions/leaderboards/index.ts
+++ b/supabase/functions/leaderboards/index.ts
@@ -1,7 +1,5 @@
 // supabase/functions/leaderboards/index.ts
-// Leaderboards API -> wraps Postgres RPCs:
-//   - lb_saves
-//   - lb_noassist_streak
+// Leaderboard API -> wraps Postgres RPC:
 //   - lb_offgrid_streak
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
@@ -69,7 +67,7 @@ serve(async (req: Request) => {
     }
 
     // Validate metric
-    if (!["noai", "novisit", "saves"].includes(String(metric))) {
+    if (String(metric) !== "novisit") {
       return err("invalid_metric", 400, { metric });
     }
 
@@ -112,13 +110,8 @@ serve(async (req: Request) => {
     const since = new Date();
     since.setMonth(since.getMonth() - 6);
 
-    // Map metric -> RPC
-    const rpcName =
-      metric === "saves"
-        ? "lb_saves"
-        : metric === "noai"
-        ? "lb_noassist_streak"
-        : "lb_offgrid_streak";
+    // RPC name for Off-Grid leaderboard
+    const rpcName = "lb_offgrid_streak";
 
     const { data, error } = await supabase.rpc(rpcName, {
       p_since: since.toISOString(),

--- a/supabase/migrations/20250904182509__drop_unused_leaderboards.sql
+++ b/supabase/migrations/20250904182509__drop_unused_leaderboards.sql
@@ -1,0 +1,3 @@
+-- Drop unused leaderboard functions
+DROP FUNCTION IF EXISTS public.lb_noassist_streak(timestamp with time zone);
+DROP FUNCTION IF EXISTS public.lb_saves(timestamp with time zone);


### PR DESCRIPTION
## Summary
- remove Leaderboards tab and show "Days without AI" leaderboard atop Friends
- fetch and render the Off-Grid leaderboard within Friends
- drop legacy leaderboard SQL functions and simplify leaderboard API

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9d9235b5c832d9f53e553ff2622f7