### PR TITLE
Hide login buttons when displaying auth forms

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -114,7 +114,11 @@
             </div>
             <div class="set-row">
               <button type="submit" class="btn btn-secondary">Create account</button>
+              <button type="button" id="btn-cancel-signup" class="btn btn-secondary">Cancel</button>
               <span id="su-msg" class="muted small"></span>
+            </div>
+            <div class="set-row">
+              <span class="muted small">Already have an account? <a href="#" id="link-show-login">Log in</a></span>
             </div>
           </form>
 
@@ -130,7 +134,11 @@
             </div>
             <div class="set-row">
               <button type="submit" class="btn btn-secondary">Log in</button>
+              <button type="button" id="btn-cancel-login" class="btn btn-secondary">Cancel</button>
               <span id="li-msg" class="muted small"></span>
+            </div>
+            <div class="set-row">
+              <span class="muted small">Need an account? <a href="#" id="link-show-signup">Sign up</a></span>
             </div>
           </form>
         </div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -206,14 +206,43 @@ async function ensureProfile(user) {
 
 // Toggle forms
 $("#btn-show-signup")?.addEventListener("click", () => {
+  hide($("#btn-show-signup"));
+  hide($("#btn-show-login"));
   hide($("#form-login"));
   show($("#form-signup"));
   $("#su-email")?.focus();
 });
 $("#btn-show-login")?.addEventListener("click", () => {
+  hide($("#btn-show-signup"));
+  hide($("#btn-show-login"));
   hide($("#form-signup"));
   show($("#form-login"));
   $("#li-email")?.focus();
+});
+
+$("#btn-cancel-signup")?.addEventListener("click", () => {
+  show($("#btn-show-signup"));
+  show($("#btn-show-login"));
+  hide($("#form-signup"));
+  $("#su-msg").textContent = "";
+});
+$("#btn-cancel-login")?.addEventListener("click", () => {
+  show($("#btn-show-signup"));
+  show($("#btn-show-login"));
+  hide($("#form-login"));
+  $("#li-msg").textContent = "";
+});
+$("#link-show-login")?.addEventListener("click", (e) => {
+  e.preventDefault();
+  hide($("#form-signup"));
+  show($("#form-login"));
+  $("#li-email")?.focus();
+});
+$("#link-show-signup")?.addEventListener("click", (e) => {
+  e.preventDefault();
+  hide($("#form-login"));
+  show($("#form-signup"));
+  $("#su-email")?.focus();
 });
 
 // -------------------------


### PR DESCRIPTION
## Summary
- hide initial Sign up/Log in buttons when displaying auth forms
- add cancel and switch links for login and signup forms
- update JS to toggle buttons/forms accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba70ac0914832db1c30a4807bacdbb