### PR TITLE
refactor: improve friends tab UI

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -145,5 +145,11 @@
 .friend-list li{ display:flex; justify-content:space-between; align-items:center; padding:6px 8px; border:1px solid var(--border); border-radius:4px; background:linear-gradient(#fefefe,#e6e6e6); }
 .friend-list li .actions{ display:flex; gap:6px; }
 .btn-sm{ padding:4px 6px; font-size:12px; }
+
+/* Friend toolbar */
+.friends-toolbar{ display:flex; justify-content:flex-end; gap:8px; }
+.icon-btn{ position:relative; width:32px; height:32px; display:flex; align-items:center; justify-content:center; border:1px solid var(--border); border-radius:4px; background:linear-gradient(#f9f9f9,#e2e2e2); cursor:pointer; font-size:16px; }
+.icon-btn:hover{ filter:brightness(.97); }
+.badge{ position:absolute; top:2px; right:2px; background:var(--danger); color:#fff; border-radius:999px; padding:0 4px; font-size:10px; }
   
   

--- a/src/popup.html
+++ b/src/popup.html
@@ -47,6 +47,12 @@
     <!-- Friends -->
     <section id="tab-friends" class="hidden">
       <div class="friends">
+        <div class="friends-toolbar">
+          <button id="toggle-requests" class="icon-btn" title="Friend requests">
+            🔔<span id="req-count" class="badge hidden"></span>
+          </button>
+          <button id="toggle-add-friend" class="icon-btn" title="Add friend">👥➕</button>
+        </div>
         <div class="board-card">
           <div class="board-head">
             <div class="board-title">Days without AI</div>
@@ -57,7 +63,7 @@
           </div>
         </div>
 
-        <div class="friend-card">
+        <div id="add-friend-card" class="friend-card hidden">
           <div class="friend-title">Add Friend</div>
           <div class="friend-row">
             <input id="add-friend-username" class="set-input-wide" placeholder="username" />
@@ -65,7 +71,7 @@
             <span id="add-friend-msg" class="muted small"></span>
           </div>
         </div>
-        <div class="friend-card">
+        <div id="friend-requests-card" class="friend-card hidden">
           <div class="friend-title">Friend Requests</div>
           <ul id="friend-requests" class="friend-list"></ul>
         </div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -575,6 +575,7 @@ async function renderFriendsTab() {
   }
 
   const reqRows = await getFriendRequests(me);
+  const countEl = $("#req-count");
   if (reqRows.length) {
     const ids = reqRows.map(r => r.requester);
     const { data: rProfiles } = await supabase
@@ -585,8 +586,10 @@ async function renderFriendsTab() {
       const name = rProfiles?.find(p => p.id === r.requester)?.username || r.requester;
       return `<li data-id="${r.requester}"><span>${name}</span><span class="actions"><button class="btn btn-secondary btn-sm accept">Accept</button><button class="btn btn-danger btn-sm decline">Decline</button></span></li>`;
     }).join('');
+    if (countEl) { countEl.textContent = reqRows.length; show(countEl); }
   } else {
     reqEl.innerHTML = "<li class='empty'>No friend requests.</li>";
+    if (countEl) hide(countEl);
   }
 }
 
@@ -623,6 +626,22 @@ $("#friend-requests")?.addEventListener("click", async (e) => {
     return;
   }
   await renderFriendsTab();
+});
+
+$("#toggle-add-friend")?.addEventListener("click", () => {
+  const card = $("#add-friend-card");
+  const reqCard = $("#friend-requests-card");
+  if (reqCard) hide(reqCard);
+  card?.classList.toggle("hidden");
+});
+
+$("#toggle-requests")?.addEventListener("click", () => {
+  const card = $("#friend-requests-card");
+  const addCard = $("#add-friend-card");
+  if (addCard) hide(addCard);
+  card?.classList.toggle("hidden");
+  const badge = $("#req-count");
+  if (badge) hide(badge);
 });
 
 // Leaderboard always shows friends; scope toggle removed


### PR DESCRIPTION
## Summary
- replace bulky friend management cards with compact icons
- show pending request count and toggle views on demand
- add styling for toolbar icon buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba730d52d4832db95ab1bc4740465a