### PR TITLE
feat: modernize popup UI

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -1,32 +1,33 @@
-/* Mid-2010s inspired palette and sharper corners */
+/* Ultra-modern liquid glass palette */
 :root{
-    --bg:#dfe3e8; --card:#ffffff; --muted:#555; --text:#222; --border:#bfc3c7;
-    --primary:#2e7d32; --danger:#c0392b; --proceed:#2e8b57; --close:#c0392b; --radius:6px;
+    --bg:#e8edf2; --card:rgba(255,255,255,0.35); --muted:#555; --text:#111; --border:rgba(255,255,255,0.4);
+    --primary:#4a90e2; --danger:#e74c3c; --proceed:#4caf50; --close:#e74c3c; --radius:12px;
   }
   *{ box-sizing:border-box }
   html,body{ width:440px; margin:0; padding:0; }
-  body{ background:linear-gradient(#fefefe, #d9d9d9); color:var(--text);
+  body{ background:linear-gradient(135deg,#dfe9f3,#ffffff); color:var(--text);
     font:13px/1.45 "Helvetica Neue", Arial, sans-serif; -webkit-font-smoothing:antialiased; }
-  
+
   /* Header */
   .hdr{ display:flex; justify-content:space-between; align-items:center; padding:12px;
-    background:linear-gradient(#388e3c, #2e7d32); color:#fff; border-bottom:1px solid #1b5e20;
-    box-shadow:0 2px 4px rgba(0,0,0,.25); }
+    background:rgba(255,255,255,0.25); backdrop-filter:blur(20px) saturate(180%);
+    color:var(--text); border-bottom:1px solid var(--border);
+    box-shadow:0 4px 20px rgba(0,0,0,.1); }
   .hdr-title{ display:flex; gap:10px; align-items:center }
   .hdr-title h1{ margin:0; font-size:16px }
-  .hdr-title .muted{ margin:2px 0 0; font-size:12px; color:#e0e0e0 }
+  .hdr-title .muted{ margin:2px 0 0; font-size:12px; color:var(--muted) }
   .hdr-logo{ width:36px; height:36px; display:grid; place-items:center;
-    background:rgba(255,255,255,.25); border:1px solid #1b5e20; border-radius:6px; }
+    background:rgba(255,255,255,.3); border:1px solid var(--border); border-radius:var(--radius); }
   .hdr-stats{ display:flex; gap:14px }
-  .stat{ text-align:center } .stat span{ display:block; font-weight:700; font-size:14px } .stat label{ display:block; color:#fff; font-size:11px }
-  
+  .stat{ text-align:center } .stat span{ display:block; font-weight:700; font-size:14px } .stat label{ display:block; color:var(--muted); font-size:11px }
+
   /* Tabs */
-  .tabs{ display:flex; gap:8px; padding:10px 12px; background:var(--card); border-bottom:1px solid var(--border); }
-  .tab{ padding:7px 12px; border-radius:0; border:1px solid var(--border);
-    background:linear-gradient(#f9f9f9, #e0e0e0); cursor:pointer; font-weight:600; color:var(--text);
-    transition:background .2s,color .2s; }
-  .tab:hover{ background:linear-gradient(#eaeaea,#d2d2d2); }
-  .tab.is-active{ background:linear-gradient(#388e3c, #2e7d32); color:#fff; border-color:#2e7d32; }
+  .tabs{ display:flex; gap:8px; padding:10px 12px; background:rgba(255,255,255,0.25); border-bottom:1px solid var(--border); backdrop-filter:blur(20px) saturate(180%); }
+  .tab{ flex:1; padding:8px 0; border-radius:var(--radius); border:1px solid var(--border);
+    background:rgba(255,255,255,0.3); cursor:pointer; font-weight:600; color:var(--text);
+    text-align:center; transition:background .3s,color .3s,transform .3s; }
+  .tab:hover{ transform:translateY(-2px); }
+  .tab.is-active{ background:var(--primary); color:#fff; border-color:var(--primary); }
   
     /* Activity summary */
     .activity-summary{ text-align:center; padding:20px 0; display:flex; flex-direction:column; align-items:center; gap:12px; }
@@ -39,23 +40,24 @@
 
 
     /* Buttons */
-    .btn{ padding:7px 10px; border-radius:4px; border:1px solid var(--border);
-      background:linear-gradient(#fefefe,#dedede); cursor:pointer; font-weight:600;
-      transition:filter .2s,transform .2s; }
-    .btn:hover{ filter:brightness(1.05); }
+    .btn{ padding:7px 10px; border-radius:8px; border:1px solid var(--border);
+      background:rgba(255,255,255,0.3); cursor:pointer; font-weight:600;
+      backdrop-filter:blur(10px) saturate(180%);
+      transition:transform .3s,box-shadow .3s; }
+    .btn:hover{ transform:translateY(-2px); box-shadow:0 4px 12px rgba(0,0,0,.15); }
     .btn:active{ transform:scale(.97); }
-    .btn-secondary{ background:linear-gradient(#f9f9f9,#e2e2e2); }
-    .btn-danger{ background:linear-gradient(#fceaea,#f9bebe); border-color:#e99; color:var(--danger) }
+    .btn-secondary{ background:rgba(255,255,255,0.25); }
+    .btn-danger{ background:rgba(231,76,60,0.1); border-color:rgba(231,76,60,0.4); color:var(--danger) }
     .actions{ display:flex; gap:8px }
   
     /* Leaderboards */
-      .board-card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 2px 6px rgba(0,0,0,.2); }
+      .board-card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 2px 6px rgba(0,0,0,.2); backdrop-filter:blur(20px) saturate(180%); }
   .board-head{ padding:10px 12px 0; } .board-title{ font-weight:700; } .board-sub{ color:var(--muted); font-size:12px; margin-top:2px; }
   .board-body{ padding:8px 12px 12px; }
   .ranklist{ display:grid; gap:6px; }
   .rankrow{ display:grid; grid-template-columns: 28px 1fr 60px; align-items:center; gap:8px;
-    padding:8px 10px; border:1px solid var(--border); border-radius:4px; background:linear-gradient(#fefefe,#e6e6e6);
-    transition:filter .2s; }
+    padding:8px 10px; border:1px solid var(--border); border-radius:4px; background:var(--card);
+    backdrop-filter:blur(20px) saturate(180%); transition:filter .2s; }
   .rankrow:hover{ filter:brightness(1.02); }
   .rankrow.me{ background:linear-gradient(#eaf7ea,#d2e8d2); border-color:#99c199; } /* highlight your row */
   .ranknum{ font-weight:800; text-align:center; }
@@ -66,7 +68,7 @@
   
   /* Settings */
   .settings{ padding:12px; display:grid; gap:12px; }
-  .set-card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 2px 6px rgba(0,0,0,.2); padding:12px; transition:box-shadow .2s; }
+  .set-card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 2px 6px rgba(0,0,0,.2); backdrop-filter:blur(20px) saturate(180%); padding:12px; transition:box-shadow .2s; }
   .set-card:hover{ box-shadow:0 4px 12px rgba(0,0,0,.25); }
   .set-title{ font-weight:700; margin-bottom:8px; }
   .set-row{ display:flex; align-items:center; gap:10px; margin:10px 0; }
@@ -87,13 +89,20 @@
 
 /* Friends */
 .friends{ padding:12px; display:grid; gap:12px; }
-.friend-card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 2px 6px rgba(0,0,0,.2); padding:12px; }
+.friend-card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 2px 6px rgba(0,0,0,.2); backdrop-filter:blur(20px) saturate(180%); padding:12px; }
 .friend-title{ font-weight:700; margin-bottom:8px; }
 .friend-row{ display:flex; align-items:center; gap:8px; margin:8px 0; }
 .friend-list{ list-style:none; margin:0; padding:0; display:grid; gap:6px; }
-.friend-list li{ display:flex; justify-content:space-between; align-items:center; padding:6px 8px; border:1px solid var(--border); border-radius:4px; background:linear-gradient(#fefefe,#e6e6e6); transition:filter .2s; }
+.friend-list li{ display:flex; justify-content:space-between; align-items:center; padding:6px 8px; border:1px solid var(--border); border-radius:4px; background:var(--card); backdrop-filter:blur(20px) saturate(180%); transition:filter .2s; }
 .friend-list li:hover{ filter:brightness(1.02); }
 .friend-list li .actions{ display:flex; gap:6px; }
 .btn-sm{ padding:4px 6px; font-size:12px; }
-  
+
+/* Animations */
+.fade-in{ animation:fade-in .4s ease; }
+@keyframes fade-in{
+  from{ opacity:0; transform:translateY(10px); }
+  to{ opacity:1; transform:translateY(0); }
+}
+
   

--- a/src/popup.js
+++ b/src/popup.js
@@ -637,7 +637,10 @@ $$(".tab").forEach(tabBtn => {
 
     tabBtn.classList.add("is-active");
     const target = "tab-" + tabBtn.dataset.tab;
-    document.getElementById(target).classList.remove("hidden");
+    const targetEl = document.getElementById(target);
+    targetEl.classList.remove("hidden");
+    targetEl.classList.add("fade-in");
+    setTimeout(() => targetEl.classList.remove("fade-in"), 400);
 
     if (target === "tab-activity") loadAndRender();
     else if (target === "tab-settings") {
@@ -654,6 +657,12 @@ $$(".tab").forEach(tabBtn => {
 // -------------------------
 loadAndRender();
 loadSettings();
+
+const firstTab = document.getElementById("tab-activity");
+if (firstTab) {
+  firstTab.classList.add("fade-in");
+  setTimeout(() => firstTab.classList.remove("fade-in"), 400);
+}
 
 (async () => {
   await restoreSession();


### PR DESCRIPTION
## Summary
- redesign popup with translucent "glass" palette and backdrop blur
- animate tab transitions and interactive elements
- expand main tabs to fill the popup width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba75db94b8832d8449d6edbc23cf1d