### PR TITLE
feat: add extension logo

### DIFF
--- a/src/icons/icon.svg
+++ b/src/icons/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#2e7d32"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">A</text>
+</svg>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,8 +3,21 @@
     "name": "aiDetox",
     "description": "Stop relying on AI to run your life for you.",
     "version": "1.0.0",
-  
-    "action": { "default_popup": "popup.html" },
+
+    "icons": {
+      "16": "icons/icon.svg",
+      "48": "icons/icon.svg",
+      "128": "icons/icon.svg"
+    },
+
+    "action": {
+      "default_popup": "popup.html",
+      "default_icon": {
+        "16": "icons/icon.svg",
+        "48": "icons/icon.svg",
+        "128": "icons/icon.svg"
+      }
+    },
   
     "permissions": ["storage", "tabs", "downloads"],
 

--- a/src/popup.css
+++ b/src/popup.css
@@ -17,6 +17,7 @@
   .hdr-title .muted{ margin:2px 0 0; font-size:12px; color:#e0e0e0 }
   .hdr-logo{ width:36px; height:36px; display:grid; place-items:center;
     background:rgba(255,255,255,.25); border:1px solid #1b5e20; border-radius:6px; }
+  .hdr-logo img{ width:100%; height:100%; }
   .hdr-stats{ display:flex; gap:14px }
   .stat{ text-align:center } .stat span{ display:block; font-weight:700; font-size:14px } .stat label{ display:block; color:#fff; font-size:11px }
   

--- a/src/popup.html
+++ b/src/popup.html
@@ -7,13 +7,13 @@
   </head>
   <body>
     <header class="hdr">
-      <div class="hdr-title">
-        <div class="hdr-logo">🧘‍♂️</div>
-        <div>
-          <h1>aiDetox</h1>
-          <p class="muted">Your AI usage journal</p>
+        <div class="hdr-title">
+          <div class="hdr-logo"><img id="logo" alt="aiDetox logo" /></div>
+          <div>
+            <h1>aiDetox</h1>
+            <p class="muted">Your AI usage journal</p>
+          </div>
         </div>
-      </div>
       <div class="hdr-stats">
         <div class="stat"><span id="stat-total">0</span><label>Total</label></div>
         <div class="stat"><span id="stat-proceed">0</span><label>Proceed</label></div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -14,6 +14,9 @@ const $$ = (s) => Array.from(document.querySelectorAll(s));
 const show = (el) => el && el.classList.remove("hidden");
 const hide = (el) => el && el.classList.add("hidden");
 
+const logoImg = $("#logo");
+if (logoImg) logoImg.src = chrome.runtime.getURL("icons/icon.svg");
+
 // Basic HTML escaping to prevent injection when building strings
 function escapeHtml(str = "") {
   return str


### PR DESCRIPTION
## Summary
- switch extension icon assets to a text-based SVG, removing PNG binaries
- reference SVG icon in manifest and popup header

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf16c4a798832d91c10f9be13c3871