### PR TITLE
Remove popup logo box

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -15,9 +15,7 @@
   .hdr-title{ display:flex; gap:10px; align-items:center }
   .hdr-title h1{ margin:0; font-size:16px }
   .hdr-title .muted{ margin:2px 0 0; font-size:12px; color:#e0e0e0 }
-  .hdr-logo{ width:36px; height:36px; display:grid; place-items:center;
-    background:rgba(255,255,255,.25); border:1px solid #1b5e20; border-radius:6px; }
-  .hdr-logo img{ width:100%; height:100%; }
+  .hdr-logo{ width:36px; height:36px; display:grid; place-items:center; }
   .hdr-logo img{ width:100%; height:100%; }
   .hdr-stats{ display:flex; gap:14px }
   .stat{ text-align:center } .stat span{ display:block; font-weight:700; font-size:14px } .stat label{ display:block; color:#fff; font-size:11px }


### PR DESCRIPTION
## Summary
- Remove background box styles from popup logo so it displays without a container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf2002b794832d8b145feeb84ff403