### PR TITLE
Constrain Supabase host to project domain

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,7 @@
     "permissions": ["storage", "tabs", "downloads"],
 
     "host_permissions": [
-      "https://*.supabase.co/*"
+      "https://ltjtjgdjllmbyknaygof.supabase.co/*"
     ], 
   
     "background": {


### PR DESCRIPTION
## Summary
- replace wildcard Supabase host with project-specific domain in manifest
- rebuild extension bundle

## Testing
- `npm test`
- `SUPABASE_URL=https://ltjtjgdjllmbyknaygof.supabase.co SUPABASE_ANON_KEY=... npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c320c21b48832da8f932412e59aff7