### PR TITLE
Remove local storage notices from UI

### DIFF
--- a/Frontend/stopllms/app/Privacy/page.tsx
+++ b/Frontend/stopllms/app/Privacy/page.tsx
@@ -47,8 +47,8 @@ export default function Privacy() {
           <h2>1. Information We Collect</h2>
           <ul>
             <li><strong>Login information:</strong> Helps keep you signed in and connects your activity to your account.</li>
-            <li><strong>Usage activity:</strong> Records which sites you interact with, when, and what action you chose (continue or block). This can be kept only on your device or also synced to your account.</li>
-            <li><strong>Reasons you provide:</strong> Notes you write before choosing to continue. These can stay on your device or be synced so you can review them later.</li>
+            <li><strong>Usage activity:</strong> Records which sites you interact with, when, and what action you chose (continue or block).</li>
+            <li><strong>Reasons you provide:</strong> Notes you write before choosing to continue.</li>
             <li><strong>Device details:</strong> A simple identifier and browser version, used to tell devices apart and fix issues.</li>
           </ul>
           <p>
@@ -70,7 +70,6 @@ export default function Privacy() {
         <section id="retention" className="scroll-mt-24">
           <h2>3. Data Retention</h2>
           <ul>
-            <li><strong>On your device:</strong> Your data stays until you uninstall the Extension or clear it in settings.</li>
             <li><strong>In the cloud:</strong> If you sync data, it stays until you delete it or your account is inactive for a long period.</li>
           </ul>
         </section>

--- a/src/popup.html
+++ b/src/popup.html
@@ -196,13 +196,11 @@
             <button id="settings-export" class="btn btn-secondary">Export CSV</button>
             <button id="settings-clear" class="btn btn-danger">Clear all</button>
           </div>
-          <div class="muted small">Data stored only on this device.</div>
         </div>
       </div>
     </section>
 
-
-    <footer class="foot muted">Data stored only on this device.</footer>
+    <footer class="foot muted"></footer>
     <script src="popup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Drop "Data stored only on this device" note from extension popup
- Remove references to keeping data only on-device in Privacy page

## Testing
- `npm test`
- `npm test` (stopllms frontend; missing script)
- `npm run lint` (stopllms frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c320fb8d58832db4ef9cbbb5950392