### PR TITLE
Update hero call-to-actions

### DIFF
--- a/Frontend/stopllms/components/sections/hero/default.tsx
+++ b/Frontend/stopllms/components/sections/hero/default.tsx
@@ -1,4 +1,5 @@
 import { ArrowRightIcon } from "lucide-react";
+import Link from "next/link";
 import { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
@@ -18,6 +19,8 @@ interface HeroButtonProps {
   variant?: ButtonProps["variant"];
   icon?: ReactNode;
   iconRight?: ReactNode;
+  target?: string;
+  rel?: string;
 }
 
 interface HeroProps {
@@ -76,15 +79,17 @@ export default function Hero({
   ),
   buttons = [
     {
-      href: "https://www.stopllms.com/",
-      text: "Get Started",
+      href: "/about",
+      text: "Learn about StopLLMs",
       variant: "default",
     },
     {
-      href: "https://www.stopllms.com/",
-      text: "Github",
+      href: "https://github.com/Deonaf24/aiDetox",
+      text: "View the GitHub repo",
       variant: "glow",
       icon: <Github className="mr-2 size-4" />,
+      target: "_blank",
+      rel: "noreferrer",
     },
   ],
   className,
@@ -107,20 +112,35 @@ export default function Hero({
           </p>
           {buttons !== false && buttons.length > 0 && (
             <div className="animate-appear relative z-10 flex justify-center gap-4 opacity-0 delay-300">
-              {buttons.map((button, index) => (
-                <Button
-                  key={index}
-                  variant={button.variant || "default"}
-                  size="lg"
-                  asChild
-                >
-                  <a href={button.href}>
-                    {button.icon}
-                    {button.text}
-                    {button.iconRight}
-                  </a>
-                </Button>
-              ))}
+              {buttons.map((button, index) => {
+                const isInternalLink = button.href.startsWith("/");
+                return (
+                  <Button
+                    key={index}
+                    variant={button.variant || "default"}
+                    size="lg"
+                    asChild
+                  >
+                    {isInternalLink ? (
+                      <Link href={button.href}>
+                        {button.icon}
+                        {button.text}
+                        {button.iconRight}
+                      </Link>
+                    ) : (
+                      <a
+                        href={button.href}
+                        target={button.target ?? "_blank"}
+                        rel={button.rel ?? "noreferrer"}
+                      >
+                        {button.icon}
+                        {button.text}
+                        {button.iconRight}
+                      </a>
+                    )}
+                  </Button>
+                );
+              })}
             </div>
           )}
           {mockup !== false && (


### PR DESCRIPTION
## Summary
- add internal navigation support with `next/link` for hero buttons
- update default hero call-to-actions to promote the About page and the StopLLMs GitHub repository

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb2aa1c3b8832db28aa2aad6857c50