### PR TITLE
Add About page and wire nav links

### DIFF
--- a/Frontend/stopllms/app/about/page.tsx
+++ b/Frontend/stopllms/app/about/page.tsx
@@ -1,0 +1,227 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import {
+  Card,
+  CardDescription,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Section } from "@/components/ui/section";
+
+export const metadata: Metadata = {
+  title: "About StopLLMs",
+  description:
+    "Learn about the mission, team, and roadmap guiding StopLLMs as we help people stay in control of their thinking.",
+};
+
+const features = [
+  {
+    title: "Mindful checkpoints",
+    description:
+      "Reflection prompts encourage you to pause, articulate intent, and decide whether AI assistance is truly needed before continuing.",
+  },
+  {
+    title: "Adaptive usage limits",
+    description:
+      "Personalized guardrails help you set healthy boundaries with daily caps, cooldowns, and context-aware reminders.",
+  },
+  {
+    title: "Progress insights",
+    description:
+      "Lightweight analytics highlight streaks, mindful wins, and trends so you can celebrate progress without feeling surveilled.",
+  },
+  {
+    title: "Community accountability",
+    description:
+      "Shared challenges and opt-in updates keep friends, teammates, and families aligned around intentional technology habits.",
+  },
+] satisfies {
+  title: string;
+  description: string;
+}[];
+
+const team = [
+  {
+    name: "Deon Aftahi",
+    role: "Co-founder & CEO",
+    bio: "Product strategist focused on designing gentle friction that restores attention and confidence without sacrificing productivity.",
+  },
+  {
+    name: "Eli Polterovich",
+    role: "Co-founder & CTO",
+    bio: "Engineer behind the StopLLMs extension, bridging behavioral science with privacy-first systems that work across modern browsers.",
+  },
+  {
+    name: "Advisors & Community",
+    role: "Researchers, educators, and early adopters",
+    bio: "A growing circle of experts and supporters pressure-test our ideas, share lived experiences, and help define responsible AI practices.",
+  },
+] satisfies {
+  name: string;
+  role: string;
+  bio: string;
+}[];
+
+const roadmap = [
+  {
+    title: "Private beta with mindful guardrails",
+    timeframe: "Q1 2025",
+    description:
+      "Invite early supporters to shape the browser extension, refine prompts, and validate gentle interventions across workflows.",
+  },
+  {
+    title: "Team and family dashboards",
+    timeframe: "Q2 2025",
+    description:
+      "Launch shared accountability spaces so groups can set norms together, review wins, and spot when AI habits drift off course.",
+  },
+  {
+    title: "Cross-platform coverage",
+    timeframe: "Q3 2025",
+    description:
+      "Expand beyond Chromium with Firefox support, mobile companions, and integrations wherever AI access decisions are made.",
+  },
+  {
+    title: "Well-being insights and rewards",
+    timeframe: "Q4 2025",
+    description:
+      "Introduce richer trends, journaling reflections, and celebratory milestones that make intentional focus feel sustainable and fun.",
+  },
+] satisfies {
+  title: string;
+  timeframe: string;
+  description: string;
+}[];
+
+export default function AboutPage() {
+  return (
+    <main className="flex flex-col">
+      <Section id="mission">
+        <div className="max-w-container mx-auto flex flex-col items-center gap-6 text-center sm:gap-8">
+          <div className="flex flex-col items-center gap-4 sm:gap-6">
+            <span className="text-primary/80 text-sm font-semibold uppercase tracking-wide">
+              Our mission
+            </span>
+            <h1 className="text-4xl leading-tight font-semibold text-balance sm:text-6xl sm:leading-tight">
+              We build gentle guardrails that keep humans in control of AI.
+            </h1>
+            <p className="text-muted-foreground max-w-3xl text-lg text-balance sm:text-xl">
+              StopLLMs helps knowledge workers, students, and teams stay sharp by introducing purposeful pauses before outsourcing tough thinking. We combine behavioral science, community accountability, and respectful technology to reinforce your own voice.
+            </p>
+          </div>
+          <div className="grid w-full gap-4 text-left sm:grid-cols-3">
+            <div className="bg-muted/40 rounded-lg p-5">
+              <h2 className="text-lg font-semibold">Protect attention</h2>
+              <p className="text-muted-foreground text-sm">
+                Minimize autopilot AI usage by giving yourself a moment to notice impulses and choose with intention.
+              </p>
+            </div>
+            <div className="bg-muted/40 rounded-lg p-5">
+              <h2 className="text-lg font-semibold">Celebrate progress</h2>
+              <p className="text-muted-foreground text-sm">
+                Track meaningful streaks and mindful wins that show how your skills are growing without AI shortcuts.
+              </p>
+            </div>
+            <div className="bg-muted/40 rounded-lg p-5">
+              <h2 className="text-lg font-semibold">Respect privacy</h2>
+              <p className="text-muted-foreground text-sm">
+                Log only what is needed—never your content—so accountability never comes at the cost of trust.
+              </p>
+            </div>
+          </div>
+          <Button asChild size="lg">
+            <Link href="#features">Explore the platform</Link>
+          </Button>
+        </div>
+      </Section>
+
+      <Section id="features" className="bg-muted/20">
+        <div className="max-w-container mx-auto flex flex-col gap-8">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <span className="text-primary/80 text-sm font-semibold uppercase tracking-wide">
+              Product pillars
+            </span>
+            <h2 className="text-3xl font-semibold text-balance sm:text-5xl">
+              Features designed for mindful technology habits.
+            </h2>
+            <p className="text-muted-foreground max-w-2xl text-balance">
+              Every interaction is crafted to reinforce agency. From gentle nudges to opt-in sharing, StopLLMs fits around your goals instead of dictating them.
+            </p>
+          </div>
+          <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+            {features.map((feature) => (
+              <Card key={feature.title}>
+                <CardTitle>{feature.title}</CardTitle>
+                <CardDescription>{feature.description}</CardDescription>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      <Section id="team">
+        <div className="max-w-container mx-auto flex flex-col gap-8">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <span className="text-primary/80 text-sm font-semibold uppercase tracking-wide">
+              The people behind StopLLMs
+            </span>
+            <h2 className="text-3xl font-semibold text-balance sm:text-5xl">
+              A team committed to healthier AI habits.
+            </h2>
+            <p className="text-muted-foreground max-w-2xl text-balance">
+              We blend entrepreneurship, engineering, and community building experience to ensure StopLLMs is practical, humane, and ready for the next generation of knowledge work.
+            </p>
+          </div>
+          <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+            {team.map((member) => (
+              <Card key={member.name}>
+                <CardTitle>{member.name}</CardTitle>
+                <CardDescription>
+                  <span className="text-primary text-sm font-semibold uppercase tracking-wide">
+                    {member.role}
+                  </span>
+                  {member.bio}
+                </CardDescription>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      <Section id="roadmap" className="bg-muted/20">
+        <div className="max-w-container mx-auto flex flex-col gap-8">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <span className="text-primary/80 text-sm font-semibold uppercase tracking-wide">
+              Roadmap
+            </span>
+            <h2 className="text-3xl font-semibold text-balance sm:text-5xl">
+              What we&apos;re building next.
+            </h2>
+            <p className="text-muted-foreground max-w-2xl text-balance">
+              Our roadmap is shaped with community feedback. Each milestone deepens the support we provide without compromising your autonomy.
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            {roadmap.map((item) => (
+              <Card key={item.title}>
+                <CardTitle>{item.title}</CardTitle>
+                <CardDescription>
+                  <span className="text-primary text-sm font-semibold uppercase tracking-wide">
+                    {item.timeframe}
+                  </span>
+                  {item.description}
+                </CardDescription>
+              </Card>
+            ))}
+          </div>
+          <div className="flex justify-center">
+            <Button asChild size="lg" variant="glow">
+              <Link href="/">Return to the homepage</Link>
+            </Button>
+          </div>
+        </div>
+      </Section>
+    </main>
+  );
+}

--- a/Frontend/stopllms/app/page.tsx
+++ b/Frontend/stopllms/app/page.tsx
@@ -3,8 +3,6 @@ import FAQ from "@/components/sections/faq/default";
 import Footer from "@/components/sections/footer/default";
 import CTA from "@/components/sections/cta/default";
 
-import Image from "next/image";
-
 export default function Home() {
   return (
     <>

--- a/Frontend/stopllms/components/sections/cta/default.tsx
+++ b/Frontend/stopllms/components/sections/cta/default.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { ReactNode } from "react";
-
 import { cn } from "@/lib/utils";
 import { Button } from "../../ui/button";
 import Glow from "../../ui/glow";

--- a/Frontend/stopllms/components/sections/faq/default.tsx
+++ b/Frontend/stopllms/components/sections/faq/default.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { ReactNode } from "react";
 
 

--- a/Frontend/stopllms/components/sections/footer/default.tsx
+++ b/Frontend/stopllms/components/sections/footer/default.tsx
@@ -45,7 +45,7 @@ export default function FooterSection({
     {
       title: "Company",
       links: [
-        { text: "About", href: "https://www.stopllms.com/" },
+        { text: "About", href: "/about" },
         { text: "Careers", href: "https://www.stopllms.com/" },
       ],
     },
@@ -60,7 +60,7 @@ export default function FooterSection({
   ],
   copyright = "© 2025 Deon Aftahi & Eli Polterovich. All rights reserved",
   policies = [
-    { text: "Privacy Policy", href: "Privacy" },
+    { text: "Privacy Policy", href: "/Privacy" },
     { text: "Terms of Service", href: "https://www.stopllms.com/" },
   ],
   showModeToggle = true,

--- a/Frontend/stopllms/components/sections/hero/default.tsx
+++ b/Frontend/stopllms/components/sections/hero/default.tsx
@@ -8,7 +8,6 @@ import { Badge } from "../../ui/badge";
 import { Button, type ButtonProps } from "../../ui/button";
 import Glow from "../../ui/glow";
 import { Mockup, MockupFrame } from "../../ui/mockup";
-import Screenshot from "../../ui/screenshot";
 import { Section } from "../../ui/section";
 import WordFlip from "../../ui/word-flip";
 
@@ -68,16 +67,16 @@ export default function Hero({
       <span className="text-muted-foreground">
         Stop LLMs is coming soon!
       </span>
-      <a href="https://www.stopllms.com/" className="flex items-center gap-1">
-        Get started
+      <a href="/about" className="flex items-center gap-1">
+        Learn more
         <ArrowRightIcon className="size-3" />
       </a>
     </Badge>
   ),
   buttons = [
     {
-      href: "https://www.stopllms.com/",
-      text: "Get Started",
+      href: "/about",
+      text: "Discover StopLLMs",
       variant: "default",
     },
     {

--- a/Frontend/stopllms/components/sections/navbar/default.tsx
+++ b/Frontend/stopllms/components/sections/navbar/default.tsx
@@ -43,14 +43,14 @@ export default function Navbar({
   name = "Stop LLMs",
   homeUrl = "/",
   mobileLinks = [
-    { text: "Getting Started", href: "https://www.stopllms.com/" },
-    { text: "Components", href: "https://www.stopllms.com/" },
-    { text: "Documentation", href: "https://www.stopllms.com/" },
+    { text: "Home", href: "/" },
+    { text: "About", href: "/about" },
+    { text: "Privacy Policy", href: "/Privacy" },
   ],
   actions = [
     {
-      text: "Coming Soon",
-      href: "https://www.stopllms.com/",
+      text: "Learn more",
+      href: "/about",
       isButton: true,
       variant: "default",
     },

--- a/Frontend/stopllms/components/ui/navigation.tsx
+++ b/Frontend/stopllms/components/ui/navigation.tsx
@@ -55,6 +55,11 @@ export default function Navigation({
       content: "components",
     },
     {
+      title: "About",
+      isLink: true,
+      href: "/about",
+    },
+    {
       title: "Documentation",
       isLink: true,
       href: "https://www.stopllms.com/",
@@ -62,61 +67,62 @@ export default function Navigation({
   ],
   components = [
     {
-      title: "Alert Dialog",
-      href: "/docs/primitives/alert-dialog",
+      title: "Mindful checkpoints",
+      href: "/about#features",
       description:
-        "A modal dialog that interrupts the user with important content and expects a response.",
+        "See how reflection prompts help you pause and choose whether AI support is really necessary.",
     },
     {
-      title: "Hover Card",
-      href: "/docs/primitives/hover-card",
+      title: "Adaptive usage limits",
+      href: "/about#features",
       description:
-        "For sighted users to preview content available behind a link.",
+        "Discover flexible caps and cooldowns that keep AI from becoming an autopilot.",
     },
     {
-      title: "Progress",
-      href: "/docs/primitives/progress",
+      title: "Progress insights",
+      href: "/about#features",
       description:
-        "Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.",
+        "Celebrate mindful streaks with privacy-respecting analytics that highlight your growth.",
     },
     {
-      title: "Scroll-area",
-      href: "/docs/primitives/scroll-area",
-      description: "Visually or semantically separates content.",
+      title: "Community accountability",
+      href: "/about#team",
+      description:
+        "Learn how shared challenges and updates keep friends, families, and teams aligned.",
     },
     {
-      title: "Tabs",
-      href: "/docs/primitives/tabs",
+      title: "Privacy-first approach",
+      href: "/about#mission",
       description:
-        "A set of layered sections of content—known as tab panels—that are displayed one at a time.",
+        "Understand the principles that ensure we only capture what is needed to build trust.",
     },
     {
-      title: "Tooltip",
-      href: "/docs/primitives/tooltip",
+      title: "Roadmap",
+      href: "/about#roadmap",
       description:
-        "A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.",
+        "Follow the milestones we are delivering with feedback from the StopLLMs community.",
     },
   ],
   logo = <LaunchUI />,
   logoTitle = "Stop LLMs",
-  logoDescription = "Landing page template built with React, Shadcn/ui and Tailwind that you can copy/paste into your project.",
-  logoHref = "https://www.stopllms.com/",
+  logoDescription = "Mindful guardrails that help you stay sharp without leaning on language models for every decision.",
+  logoHref = "/",
   introItems = [
     {
-      title: "Introduction",
-      href: "https://www.stopllms.com/",
+      title: "Mission & values",
+      href: "/about#mission",
       description:
-        "Re-usable components built using Radix UI and Tailwind CSS.",
+        "See how StopLLMs keeps humans in control of AI-assisted work.",
     },
     {
-      title: "Installation",
-      href: "https://www.stopllms.com/",
-      description: "How to install dependencies and structure your app.",
+      title: "Features overview",
+      href: "/about#features",
+      description: "Explore the mindful checkpoints, limits, and insights we provide.",
     },
     {
-      title: "Typography",
-      href: "https://www.stopllms.com/",
-      description: "Styles for headings, paragraphs, lists...etc",
+      title: "Roadmap",
+      href: "/about#roadmap",
+      description: "Track the milestones we&apos;re building with our community.",
     },
   ],
 }: NavigationProps) {


### PR DESCRIPTION
## Summary
- add an /about route with mission, features, team, and roadmap content that uses existing section and card components
- point the navigation menu, hero CTA, footer, and mobile actions to the new About page
- clean up unused imports so eslint runs without warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb2ad1ee9c832db69c3fe3a956fb63