### PR TITLE
Add fade-bottom-soft utility for hero section

### DIFF
--- a/Frontend/stopllms/components/sections/hero/default.tsx
+++ b/Frontend/stopllms/components/sections/hero/default.tsx
@@ -92,7 +92,7 @@ export default function Hero({
   return (
     <Section
       className={cn(
-        "fade-bottom overflow-hidden pb-0 sm:pb-0 md:pb-0",
+        "fade-bottom-soft overflow-hidden pb-0 sm:pb-0 md:pb-0",
         className,
       )}
     >

--- a/Frontend/stopllms/styles/utils.css
+++ b/Frontend/stopllms/styles/utils.css
@@ -39,6 +39,9 @@
 @utility fade-bottom {
   mask-image: linear-gradient(to top, transparent 0%, black 35%);
 }
+@utility fade-bottom-soft {
+  mask-image: linear-gradient(to top, transparent 0%, black 15%);
+}
 @utility fade-top-lg {
   mask-image: linear-gradient(to bottom, transparent 15%, black 100%);
 }


### PR DESCRIPTION
## Summary
- add a fade-bottom-soft utility with a gentler mask gradient
- switch the hero section to use the softer fade while leaving other fades unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb2ac74074832d8cdadb7e0a88c017